### PR TITLE
Allow option to generate feed of all posts

### DIFF
--- a/feed.js
+++ b/feed.js
@@ -21,6 +21,8 @@ module.exports = function(locals, render, callback){
     limit: 20
   }, config.feed);
 
+  var limit = (feedConfig.limit === false) ? undefined : feedConfig.limit;
+
   // Restrict feed type
   if (feedConfig.type !== 'atom' && feedConfig.type !== 'rss2'){
     feedConfig.type = 'atom';
@@ -45,7 +47,7 @@ module.exports = function(locals, render, callback){
 
   var xml = template({
     config: config,
-    posts: locals.posts.sort('date', -1).limit(feedConfig.limit),
+    posts: locals.posts.sort('date', -1).limit(limit),
     feed_url: config.root + feedConfig.path
   });
 


### PR DESCRIPTION
Allow a special value, `false` for `feed.limit`, which will export all posts.
