### PR TITLE
apply root path to permalinks

### DIFF
--- a/atom.ejs
+++ b/atom.ejs
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
+  <% var url = config.url + config.root %>
   <title><%-: config.title | cdata %></title>
   <% if (config.subtitle){ %><subtitle><%-: config.subtitle | cdata %></subtitle><% } %>
   <link href="<%- encodeURI(feed_url) %>" rel="self"/>
-  <link href="<%- encodeURI(config.url) %>/"/>
+  <link href="<%- encodeURI(url) %>/"/>
   <updated><%= posts.first().updated.toISOString() %></updated>
-  <id><%- config.url %>/</id>
+  <id><%- url %>/</id>
   <% if (config.author){ %>
   <author>
     <name><%-: config.author | cdata %></name>
@@ -16,8 +17,8 @@
   <% posts.each(function(post){ %>
   <entry>
     <title><%-: post.title | cdata %></title>
-    <link href="<%- encodeURI(post.permalink) %>"/>
-    <id><%- post.permalink %></id>
+    <link href="<%- encodeURI(url + post.path) %>"/>
+    <id><%- url + post.path %></id>
     <published><%= post.date.toISOString() %></published>
     <updated><%= post.updated.toISOString() %></updated>
     <content type="html"><%-: post.content | cdata %></content>
@@ -27,7 +28,7 @@
     <% } else {%><%-: post.content.substring(0, 140) | cdata %><% } %>
     </summary>
     <% [].concat(post.tags.toArray(), post.categories.toArray()).forEach(function(category){ %>
-      <category term="<%= category.name %>" scheme="<%- encodeURI(category.permalink) %>"/>
+      <category term="<%= category.name %>" scheme="<%- encodeURI(url + category.path) %>"/>
     <% }) %>
   </entry>
   <% }) %>

--- a/rss2.ejs
+++ b/rss2.ejs
@@ -3,8 +3,9 @@
   xmlns:atom="http://www.w3.org/2005/Atom"
   xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
+    <% var url = config.url + config.root %>
     <title><%-: config.title | cdata %></title>
-    <link><%- encodeURI(config.url) %>/</link>
+    <link><%- encodeURI(url) %>/</link>
     <atom:link href="<%- encodeURI(feed_url) %>" rel="self" type="application/rss+xml"/>
     <description><%-: config.description | cdata %></description>
     <pubDate><%= posts.first().updated.toDate().toUTCString() %></pubDate>
@@ -12,8 +13,8 @@
     <% posts.each(function(post){ %>
     <item>
       <title><%-: post.title | cdata %></title>
-      <link><%- encodeURI(post.permalink) %></link>
-      <guid><%- encodeURI(post.permalink) %></guid>
+      <link><%- encodeURI(url + post.path) %></link>
+      <guid><%- encodeURI(url + post.path) %></guid>
       <pubDate><%= post.date.toDate().toUTCString() %></pubDate>
       <description>
       <% if (post.description){ %><%-: post.description | cdata %>
@@ -21,7 +22,7 @@
       <% } else {%><%-: post.content.substring(0, 140) | cdata %><% } %>
       </description>
       <content:encoded><%-: post.content | cdata %></content:encoded>
-      <% if (post.comments){ %><comments><%- encodeURI(post.permalink) %>#disqus_comments</comments><% } %>
+      <% if (post.comments){ %><comments><%- encodeURI(url + post.path) %>#disqus_comments</comments><% } %>
     </item>
     <% }) %>
   </channel>


### PR DESCRIPTION
Currently, root path is not considered in feed plugin.

if root is described in `_config.yml` like this
```
url: http://domain.url
root: /blog/
```
then each url of posts will be

- domain.url/blog/permalink1
- domain.url/blog/permalink2

but urls in feed are not matched. 