### PR TITLE
Support PubSubHubbub protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ feed:
   type: atom
   path: atom.xml
   limit: 20
+  hub:
 ```
 
 - **type** - Feed type. (atom/rss2)
 - **path** - Feed path. (Default: atom.xml/rss2.xml)
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts)
+- **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)

--- a/atom.xml
+++ b/atom.xml
@@ -3,6 +3,7 @@
   <title>{{ config.title | e }}</title>
   {% if config.subtitle %}<subtitle>{{ config.subtitle | e }}</subtitle>{% endif %}
   <link href="{{ feed_url | uriencode }}" rel="self"/>
+  {% if config.feed.hub %}<link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
   <link href="{{ url | uriencode }}"/>
   <updated>{{ posts.first().updated.toISOString() }}</updated>
   <id>{{ url }}</id>

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var pathFn = require('path');
 
 var config = hexo.config.feed = assign({
   type: 'atom',
-  limit: 20
+  limit: 20,
+  hub: ''
 }, hexo.config.feed);
 
 var type = config.type.toLowerCase();

--- a/rss2.xml
+++ b/rss2.xml
@@ -6,6 +6,7 @@
     <title>{{ config.title | e }}</title>
     <link>{{ url | uriencode }}</link>
     <atom:link href="{{ feed_url | uriencode }}" rel="self" type="application/rss+xml"/>
+    {% if config.feed.hub %}<atom:link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
     <description>{{ config.description | e }}</description>
     <pubDate>{{ posts.first().updated.toDate().toUTCString() }}</pubDate>
     <generator>http://hexo.io/</generator>


### PR DESCRIPTION
> **[PubSubHubbub](https://github.com/pubsubhubbub/PubSubHubbub)** is an open protocol for distributed publish/subscribe communication on the Internet. It generalizes the concept of webhooks and allows data producers and data consumers to work in a decoupled way.
> PubSubHubbub provides a way to subscribe, unsubscribe and receive updates from a resource, whether it's an RSS or Atom feed or any web accessible document (JSON...).

This patch add the PubSubHubbub Discovery protocol support to atom.xml and rss2.xml. Feedly and Inoreader support PubSubHubbub Subscription protocol now, so it will help your subscribers get notification faster.