### PR TITLE
Added back HTML escaping with CDATA

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title>{{ config.title | e }}</title>
-  {% if config.subtitle %}<subtitle>{{ config.subtitle | e }}</subtitle>{% endif %}
+  <title>{{ config.title }}</title>
+  {% if config.subtitle %}<subtitle>{{ config.subtitle }}</subtitle>{% endif %}
   <link href="{{ feed_url | uriencode }}" rel="self"/>
   {% if config.feed.hub %}<link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
   <link href="{{ url | uriencode }}"/>
@@ -9,28 +9,28 @@
   <id>{{ url }}</id>
   {% if config.author %}
   <author>
-    <name>{{ config.author | e }}</name>
-    {% if config.email %}<email>{{ config.email | e }}</email>{% endif %}
+    <name>{{ config.author }}</name>
+    {% if config.email %}<email>{{ config.email }}</email>{% endif %}
   </author>
   {% endif %}
   <generator uri="http://hexo.io/">Hexo</generator>
   {% for post in posts.toArray() %}
   <entry>
-    <title>{{ post.title | e }}</title>
+    <title>{{ post.title }}</title>
     <link href="{{ (url + post.path) | uriencode }}"/>
     <id>{{ url + post.path }}</id>
     <published>{{ post.date.toISOString() }}</published>
     <updated>{{ post.updated.toISOString() }}</updated>
-    {% if config.feed.content %}
-    <content type="html">{{ post.content | e }}</content>
+    {% if config.feed.content and post.content %}
+    <content type="html"><![CDATA[{{ post.content | safe }}]]></content>
     {% endif %}
     <summary type="html">
     {% if post.description %}
-      {{ post.description | e }}
+      {{ post.description }}
     {% elif post.excerpt %}
-      {{ post.excerpt | e }}
+      {{ post.excerpt }}
     {% elif post.content %}
-      {{ post.content.substring(0, 140) | e }}
+      {{ post.content.substring(0, 140) }}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -5,11 +5,6 @@ var env = new nunjucks.Environment();
 var pathFn = require('path');
 var fs = require('fs');
 
-nunjucks.configure({
-  autoescape: false,
-  watch: false
-});
-
 env.addFilter('uriencode', function(str) {
   return encodeURI(str);
 });

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "^1.3.4",
+    "nunjucks": "^2.4.1",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
-    "cheerio": "^0.19.0",
-    "eslint": "^1.10.3",
-    "eslint-config-hexo": "^1.0.2",
+    "chai": "^3.5.0",
+    "cheerio": "^0.20.0",
+    "eslint": "^2.4.0",
+    "eslint-config-hexo": "^1.0.3",
     "hexo": "^3.0.0",
-    "jscs": "^2.9.0",
+    "jscs": "^2.11.0",
     "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^2.0.1",
+    "mocha": "^2.4.5",
     "istanbul": "^0.4.2"
   }
 }

--- a/rss2.xml
+++ b/rss2.xml
@@ -3,30 +3,30 @@
   xmlns:atom="http://www.w3.org/2005/Atom"
   xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
-    <title>{{ config.title | e }}</title>
+    <title>{{ config.title }}</title>
     <link>{{ url | uriencode }}</link>
     <atom:link href="{{ feed_url | uriencode }}" rel="self" type="application/rss+xml"/>
     {% if config.feed.hub %}<atom:link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
-    <description>{{ config.description | e }}</description>
+    <description>{{ config.description }}</description>
     <pubDate>{{ posts.first().updated.toDate().toUTCString() }}</pubDate>
     <generator>http://hexo.io/</generator>
     {% for post in posts.toArray() %}
     <item>
-      <title>{{ post.title | e }}</title>
+      <title>{{ post.title }}</title>
       <link>{{ (url + post.path) | uriencode }}</link>
       <guid>{{ (url + post.path) | uriencode }}</guid>
       <pubDate>{{ post.date.toDate().toUTCString() }}</pubDate>
       <description>
       {% if post.description %}
-        {{ post.description | e }}
+        {{ post.description }}
       {% elif post.excerpt %}
-        {{ post.excerpt | e }}
+        {{ post.excerpt }}
       {% elif post.content %}
-        {{ post.content.substring(0, 140) | e }}
+        {{ post.content.substring(0, 140) }}
       {% endif %}
       </description>
-      {% if config.feed.content %}
-      <content:encoded>{{ post.content | e }}</content:encoded>
+      {% if config.feed.content and post.content %}
+      <content:encoded><![CDATA[{{ post.content | safe }}]]></content:encoded>
       {% endif %}
       {% if post.comments %}<comments>{{ (url + post.path) | uriencode }}#disqus_thread</comments>{% endif %}
     </item>

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,9 @@ describe('Feed generator', function() {
   });
   var Post = hexo.model('Post');
   var generator = require('../lib/generator').bind(hexo);
+
+  (require('../node_modules/hexo/lib/plugins/helper'))(hexo);
+
   var posts;
   var locals;
 

--- a/test/index.js
+++ b/test/index.js
@@ -98,7 +98,7 @@ describe('Feed generator', function() {
     }));
   });
 
-  it('Preserves HTML in the content field', function(){
+  it('Preserves HTML in the content field', function() {
     hexo.config.feed = {
       type: 'rss2',
       path: 'rss2.xml',
@@ -127,7 +127,6 @@ describe('Feed generator', function() {
     description.should.be.equal('<h6>TestHTML</h6>');
 
   });
-
 
   it('Relative URL handling', function() {
     hexo.config.feed = {

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,6 @@ var fs = require('fs');
 var assign = require('object-assign');
 var cheerio = require('cheerio');
 
-nunjucks.configure({
-  autoescape: false,
-  watch: false
-});
-
 env.addFilter('uriencode', function(str) {
   return encodeURI(str);
 });
@@ -39,7 +34,7 @@ describe('Feed generator', function() {
 
   before(function() {
     return Post.insert([
-      {source: 'foo', slug: 'foo', date: 1e8},
+      {source: 'foo', slug: 'foo', content: '<h6>TestHTML</h6>', date: 1e8},
       {source: 'bar', slug: 'bar', date: 1e8 + 1},
       {source: 'baz', slug: 'baz', date: 1e8 - 1}
     ]).then(function(data) {
@@ -103,6 +98,37 @@ describe('Feed generator', function() {
     }));
   });
 
+  it('Preserves HTML in the content field', function(){
+    hexo.config.feed = {
+      type: 'rss2',
+      path: 'rss2.xml',
+      content: true
+    };
+    var result = generator(locals);
+    var $ = cheerio.load(result.data, {xmlMode: true});
+
+    var description = $('content\\\:encoded').html()
+      .replace(/^<!\[CDATA\[/, '')
+      .replace(/\]\]>$/, '');
+
+    description.should.be.equal('<h6>TestHTML</h6>');
+
+    hexo.config.feed = {
+      type: 'atom',
+      path: 'atom.xml',
+      content: true
+    };
+    result = generator(locals);
+    $ = cheerio.load(result.data, {xmlMode: true});
+    description = $('content[type="html"]').html()
+      .replace(/^<!\[CDATA\[/, '')
+      .replace(/\]\]>$/, '');
+
+    description.should.be.equal('<h6>TestHTML</h6>');
+
+  });
+
+
   it('Relative URL handling', function() {
     hexo.config.feed = {
       type: 'atom',
@@ -132,4 +158,5 @@ describe('Feed generator', function() {
     checkURL('http://localhost/b/l/o/g', '/', 'http://localhost/b/l/o/g/');
 
   });
+
 });


### PR DESCRIPTION
Not all modern readers do support for escaped HTML in XML. But all readers support HTML within CDATA.