### PR TITLE
Add configurable footer to posts

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -22,7 +22,12 @@
     <published>{{ post.date.toISOString() }}</published>
     <updated>{{ post.updated.toISOString() }}</updated>
     {% if config.feed.content %}
-    <content type="html">{{ post.content | e }}</content>
+    <content type="html">
+      {{ post.content | e }}
+      {% if config.feed.footer %}
+        {{ config.feed.footer | e }}
+      {% endif %}
+    </content>
     {% endif %}
     <summary type="html">
     {% if post.description %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -26,7 +26,12 @@
       {% endif %}
       </description>
       {% if config.feed.content %}
-      <content:encoded>{{ post.content | e }}</content:encoded>
+      <content:encoded>
+        {{ post.content | e }}
+        {% if config.feed.footer %}
+            {{ config.feed.footer | e }}
+        {% endif %}
+      </content:encoded>
       {% endif %}
       {% if post.comments %}<comments>{{ (url + post.path) | uriencode }}#disqus_thread</comments>{% endif %}
     </item>


### PR DESCRIPTION
I've added an optional footer to your atom.xml and rss2.xml files, to accomplish a similar goal to [this wordpress plugin](https://yoast.com/wordpress/plugins/rss-footer/).