### PR TITLE
Strip html from feed description/summary

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -28,9 +28,9 @@
     {% if post.description %}
       {{ post.description }}
     {% elif post.excerpt %}
-      {{ post.excerpt }}
+      {{ post.excerpt | striptags }}
     {% elif post.content %}
-      {{ post.content.substring(0, 140) }}
+      {{ post.content | striptags | truncate(140) }}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -21,9 +21,9 @@
       {% if post.description %}
         {{ post.description }}
       {% elif post.excerpt %}
-        {{ post.excerpt }}
+        {{ post.excerpt | striptags }}
       {% elif post.content %}
-        {{ post.content.substring(0, 140) }}
+        {{ post.content | striptags | truncate(140) }}
       {% endif %}
       </description>
       {% if config.feed.content and post.content %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -8,6 +8,7 @@
     <atom:link href="{{ feed_url | uriencode }}" rel="self" type="application/rss+xml"/>
     {% if config.feed.hub %}<atom:link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
     <description>{{ config.description }}</description>
+    {% if config.language %}<language>{{ config.language }}</language>{% endif %}
     <pubDate>{{ posts.first().updated.toDate().toUTCString() }}</pubDate>
     <generator>http://hexo.io/</generator>
     {% for post in posts.toArray() %}


### PR DESCRIPTION
Using nunjucks `striptags` to remove formatting that was messing with rss/atom description/summary tag.

Before: 

> `&lt;h2 id=&quot;I-am-exactly-as-cool-as-I-was-before-I-started-writing-clojure&quot;&gt;&lt;a href=&quot;#I-am-exactly-as-cool-as-I-was-before-I-started-writing-clo`

After:

> I am exactly as cool as I was before I started writing clojure.I’ve had a short, short life as a programmer and I’ve spent a lot of it...
