### PR TITLE
Only shorten feeds at occurrences of delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ feed:
   hub:
   content:
   content_limit: 140
+  content_limit_delim: ' '
 ```
 
 - **type** - Feed type. (atom/rss2)
@@ -36,4 +37,5 @@ feed:
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts)
 - **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)
 - **content** - (optional) set to 'true' to include the contents of the entire post in the feed.
-  **content_limit** - (optional) Default length of post content used in summary. Only used, if **content** setting is false and no custom post description present.
+- **content_limit** - (optional) Default length of post content used in summary. Only used, if **content** setting is false and no custom post description present.
+- **content_limit_delim** - (optional) If **content_limit** is used to shorten post contents, only cut at the last occurrence of this delimiter before reaching the character limit. Not used by default.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ feed:
   hub:
   content:
   content_limit: 140
-  content_limit_delim: ' '
+  content_limit_delim: [".", ":", ",", " "]
 ```
 
 - **type** - Feed type. (atom/rss2)
@@ -38,4 +38,4 @@ feed:
 - **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)
 - **content** - (optional) set to 'true' to include the contents of the entire post in the feed.
 - **content_limit** - (optional) Default length of post content used in summary. Only used, if **content** setting is false and no custom post description present.
-- **content_limit_delim** - (optional) If **content_limit** is used to shorten post contents, only cut at the last occurrence of this delimiter before reaching the character limit. Not used by default.
+- **content_limit_delim** - (optional) A list of delimiters used to shorten the post content to a feed summary, if **content_limit** is set. If any of the contained delimiters is contained in the post content, cut at its occurence instead of the exact position according to **content_limit**. Delimiters in the list are probed in order for occurrence in the post content. Not used by default.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ feed:
   limit: 20
   hub:
   content:
+  content_limit: 140
 ```
 
 - **type** - Feed type. (atom/rss2)
@@ -35,3 +36,4 @@ feed:
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts)
 - **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)
 - **content** - (optional) set to 'true' to include the contents of the entire post in the feed.
+  **content_limit** - (optional) Default length of post content used in summary. Only used, if **content** setting is false and no custom post description present.

--- a/atom.xml
+++ b/atom.xml
@@ -37,7 +37,6 @@
         {{ delim_pos }}
 	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}
-	  {{ post.raw }}
           {{ short_content.substring(0, delim_pos+1) }}
         {% else %}
           {{ short_content }}

--- a/atom.xml
+++ b/atom.xml
@@ -37,7 +37,7 @@
         {{ delim_pos }}
 	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}
-          {{ short_content.substring(0, delim_pos+1) }}
+          {{ short_content.substring(0, delim_pos) }}
         {% else %}
           {{ short_content }}
         {% endif %}

--- a/atom.xml
+++ b/atom.xml
@@ -34,6 +34,7 @@
       {% if config.feed.content_limit_delim %}
         {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
         {{ delim_pos }}
+	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}
           {{ short_content.substring(0, delim_pos+1) }}
         {% else %}

--- a/atom.xml
+++ b/atom.xml
@@ -34,10 +34,11 @@
       {% if config.feed.content_limit_delim %}
         {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
 	{{ short_content }}
+	{{ short_content.lastIndexOf(config.feed.content_limit_delim) }}
         {{ delim_pos }}
 	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}
-          {{ short_content.substring(0, delim_pos) }}
+          {{ short_content.substring(0, delim_pos+1) }}
         {% else %}
           {{ short_content }}
         {% endif %}

--- a/atom.xml
+++ b/atom.xml
@@ -37,7 +37,7 @@
           {{ short_content.substring(0, delim_pos) }}
         {% else %}
           {{ short_content }}
-        {% end %}
+        {% endif %}
       {% else %}
         {{ short_content }}
       {% endif %}

--- a/atom.xml
+++ b/atom.xml
@@ -30,21 +30,7 @@
     {% elif post.excerpt %}
       {{ post.excerpt }}
     {% elif post.content %}
-      {% set short_content = post.content.substring(0, config.feed.content_limit) %}
-      {% if config.feed.content_limit_delim %}
-        {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
-	{{ short_content }}
-	{{ short_content.lastIndexOf(config.feed.content_limit_delim) }}
-        {{ delim_pos }}
-	{{ delim_pos > -1 }}
-        {% if delim_pos > -1 %}
-          {{ short_content.substring(0, delim_pos+1) }}
-        {% else %}
-          {{ short_content }}
-        {% endif %}
-      {% else %}
-        {{ short_content }}
-      {% endif %}
+       {{ post.feedShortContent }}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/atom.xml
+++ b/atom.xml
@@ -30,7 +30,7 @@
     {% elif post.excerpt %}
       {{ post.excerpt }}
     {% elif post.content %}
-      {{ post.content.substring(0, config.content_limit) }}
+      {{ post.content.substring(0, config.feed.content_limit) }}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/atom.xml
+++ b/atom.xml
@@ -30,7 +30,7 @@
     {% elif post.excerpt %}
       {{ post.excerpt }}
     {% elif post.content %}
-      {{ post.content.substring(0, 140) }}
+      {{ post.content.substring(0, config.content_limit) }}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/atom.xml
+++ b/atom.xml
@@ -33,6 +33,7 @@
       {% set short_content = post.content.substring(0, config.feed.content_limit) %}
       {% if config.feed.content_limit_delim %}
         {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
+	{{ short_content }}
         {{ delim_pos }}
 	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}

--- a/atom.xml
+++ b/atom.xml
@@ -30,7 +30,17 @@
     {% elif post.excerpt %}
       {{ post.excerpt }}
     {% elif post.content %}
-      {{ post.content.substring(0, config.feed.content_limit) }}
+      {% set short_content = post.content.substring(0, config.feed.content_limit) %}
+      {% if config.feed.content_limit_delim %}
+        {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
+        {% if delim_pos > -1 %}
+          {{ short_content.substring(0, delim_pos) }}
+        {% else %}
+          {{ short_content }}
+        {% end %}
+      {% else %}
+        {{ short_content }}
+      {% endif %}
     {% endif %}
     </summary>
     {% for category in post.categories.toArray() %}

--- a/atom.xml
+++ b/atom.xml
@@ -33,8 +33,9 @@
       {% set short_content = post.content.substring(0, config.feed.content_limit) %}
       {% if config.feed.content_limit_delim %}
         {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
+        {{ delim_pos }}
         {% if delim_pos > -1 %}
-          {{ short_content.substring(0, delim_pos) }}
+          {{ short_content.substring(0, delim_pos+1) }}
         {% else %}
           {{ short_content }}
         {% endif %}

--- a/atom.xml
+++ b/atom.xml
@@ -36,6 +36,7 @@
         {{ delim_pos }}
 	{{ delim_pos > -1 }}
         {% if delim_pos > -1 %}
+	  {{ post.raw }}
           {{ short_content.substring(0, delim_pos+1) }}
         {% else %}
           {{ short_content }}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var config = hexo.config.feed = assign({
   type: 'atom',
   limit: 20,
   hub: '',
-  content: true
+  content: true,
+  content_limit: 140
 }, hexo.config.feed);
 
 var type = config.type.toLowerCase();

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var config = hexo.config.feed = assign({
   limit: 20,
   hub: '',
   content: true,
-  content_limit: 140
+  content_limit: 140,
+  content_limit_delim: ''
 }, hexo.config.feed);
 
 var type = config.type.toLowerCase();

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,6 +4,7 @@ var nunjucks = require('nunjucks');
 var env = new nunjucks.Environment();
 var pathFn = require('path');
 var fs = require('fs');
+var hexoutil = require('hexo-util');
 
 env.addFilter('uriencode', function(str) {
   return encodeURI(str);
@@ -21,6 +22,23 @@ module.exports = function(locals) {
 
   var posts = locals.posts.sort('-date');
   if (feedConfig.limit) posts = posts.limit(feedConfig.limit);
+	
+  posts.forEach(function(post) {
+	  var safe_content = hexoutil.stripHTML(post.content);
+	  post.feedShortContent = safe_content.substring(0, feedConfig.content_limit);
+	  
+          if (typeof feedConfig.content_limit_delim != 'undefined') {
+		var delim_pos = -1;
+		for (var ind in feedConfig.content_limit_delim) {
+			var delim = feedConfig.content_limit_delim[ind];
+			delim_pos = post.feedShortContent.lastIndexOf(delim);
+			if (delim_pos > -1) {
+				post.feedShortContent = post.feedShortContent.substring(0, delim_pos+1);
+				break;
+			}
+		}
+	  }
+  });
 
   var url = config.url;
   if (url[url.length - 1] !== '/') url += '/';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-feed",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Feed generator plugin for Hexo",
   "main": "index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-feed",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Feed generator plugin for Hexo",
   "main": "index",
   "scripts": {

--- a/rss2.xml
+++ b/rss2.xml
@@ -22,7 +22,7 @@
       {% elif post.excerpt %}
         {{ post.excerpt }}
       {% elif post.content %}
-        {{ post.content.substring(0, config.content_limit) }}
+        {{ post.content.substring(0, config.feed.content_limit) }}
       {% endif %}
       </description>
       {% if config.feed.content and post.content %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -22,7 +22,7 @@
       {% elif post.excerpt %}
         {{ post.excerpt }}
       {% elif post.content %}
-        {{ post.content.substring(0, 140) }}
+        {{ post.content.substring(0, config.content_limit) }}
       {% endif %}
       </description>
       {% if config.feed.content and post.content %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -22,7 +22,17 @@
       {% elif post.excerpt %}
         {{ post.excerpt }}
       {% elif post.content %}
-        {{ post.content.substring(0, config.feed.content_limit) }}
+        {% set short_content = post.content.substring(0, config.feed.content_limit) %}
+        {% if config.feed.content_limit_delim %}
+          {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
+          {% if delim_pos > -1 %}
+            {{ short_content.substring(0, delim_pos) }}
+          {% else %}
+            {{ short_content }}
+          {% endif %}
+        {% else %}
+          {{ short_content }}
+        {% endif %}
       {% endif %}
       </description>
       {% if config.feed.content and post.content %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -22,17 +22,7 @@
       {% elif post.excerpt %}
         {{ post.excerpt }}
       {% elif post.content %}
-        {% set short_content = post.content.substring(0, config.feed.content_limit) %}
-        {% if config.feed.content_limit_delim %}
-          {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
-          {% if delim_pos > -1 %}
-            {{ short_content.substring(0, delim_pos) }}
-          {% else %}
-            {{ short_content }}
-          {% endif %}
-        {% else %}
-          {{ short_content }}
-        {% endif %}
+       {{ post.feedShortContent }}
       {% endif %}
       </description>
       {% if config.feed.content and post.content %}


### PR DESCRIPTION
With the content limit (default: 140) it can happen, that words are cut in the middle. This option allows to specify a list of delimiters which are used when shortening post contents:
- We only cut at occurrences of the specified delimiters;
- We probe the delimiters in order, and use the first one for shortening that occurs in the post content;
- If none of them occurs, we cut at **content_limit** (e.g. 140);