### PR TITLE
Support for "atom:icon" element

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ config.title }}</title>
+  {% if icon %}<icon>{{ icon }}</icon>{% endif %}
   {% if config.subtitle %}<subtitle>{{ config.subtitle }}</subtitle>{% endif %}
   <link href="{{ feed_url | uriencode }}" rel="self"/>
   {% if config.feed.hub %}<link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,6 +4,7 @@ var nunjucks = require('nunjucks');
 var env = new nunjucks.Environment();
 var pathFn = require('path');
 var fs = require('fs');
+var gravatar = require('hexo/lib/plugins/helper/gravatar');
 
 env.addFilter('uriencode', function(str) {
   return encodeURI(str);
@@ -33,9 +34,13 @@ module.exports = function(locals) {
   var url = config.url;
   if (url[url.length - 1] !== '/') url += '/';
 
+  var icon;
+  if (config.email) icon = gravatar(config.email);
+
   var xml = template.render({
     config: config,
     url: url,
+    icon: icon,
     posts: posts,
     feed_url: config.root + feedConfig.path
   });


### PR DESCRIPTION
support ["atom:icon"](https://tools.ietf.org/html/rfc4287#page-19) element with `config.email` using [hexojs gravatar helper](https://github.com/hexojs/hexo/blob/master/lib/plugins/helper/gravatar.js)