### PR TITLE
Support "intro" tag as description

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install hexo-generator-feed --save
 
 ## Use
 
-In the [front-matter](https://hexo.io/docs/front-matter.html) of your post, you can optionally add a `description` setting to write a summary for the post. Otherwise the summary will default to the excerpt or the first 140 characters of the post.
+In the [front-matter](https://hexo.io/docs/front-matter.html) of your post, you can optionally add a `description`, `intro` or `excerpt` setting to write a summary for the post. Otherwise the summary will default to the excerpt or the first 140 characters of the post.
 
 ## Options
 

--- a/atom.xml
+++ b/atom.xml
@@ -28,6 +28,8 @@
     <summary type="html">
     {% if post.description %}
       {{ post.description }}
+    {% elif post.intro %}
+      {{ post.intro }}
     {% elif post.excerpt %}
       {{ post.excerpt }}
     {% elif post.content %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -19,6 +19,8 @@
       <description>
       {% if post.description %}
         {{ post.description }}
+      {% elif post.intro %}
+        {{ post.intro }}
       {% elif post.excerpt %}
         {{ post.excerpt }}
       {% elif post.content %}


### PR DESCRIPTION
[Flexy](https://github.com/sjaakvandenberg/flexy), the theme I'm currently using with Hexo, uses the `intro` front-matter tag to generate a short description for the post.

Supporting it directly in the RSS feed generator could save a lot of duplicate lines in posts' headers at seemingly no expense.