### PR TITLE
Add ability to customize atom:icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ feed:
   content_limit: 140
   content_limit_delim: ' '
   order_by: -date
+  icon: icon.png
 ```
 
 - **type** - Feed type. (atom/rss2)
@@ -41,3 +42,4 @@ feed:
 - **content_limit** - (optional) Default length of post content used in summary. Only used, if **content** setting is false and no custom post description present.
 - **content_limit_delim** - (optional) If **content_limit** is used to shorten post contents, only cut at the last occurrence of this delimiter before reaching the character limit. Not used by default.
 - **order_by** - Feed order-by. (Default: -date)
+- **icon** - (optional) Custom feed icon. Defaults to a gravatar of email specified in the main config.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -35,7 +35,8 @@ module.exports = function(locals) {
   if (url[url.length - 1] !== '/') url += '/';
 
   var icon;
-  if (config.email) icon = gravatar(config.email);
+  if (feedConfig.icon) icon = url + feedConfig.icon;
+  else if (config.email) icon = gravatar(config.email);
 
   var xml = template.render({
     config: config,


### PR DESCRIPTION
This PR improves PR #57 and adds possibility to customize atom:icon by specifying `icon` property in feed section of `_config.yml`.