### PR TITLE
fix: TypeError: Object.assignn is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var pathFn = require('path');
 
-var config = hexo.config.feed = Object.assignn({
+var config = hexo.config.feed = Object.assign({
   type: 'atom',
   limit: 20,
   hub: '',


### PR DESCRIPTION
Sorry, I made mistake when reviewed #70 
Current master branch has an error. `Object.assign` spell is wrong.

```sh
ERROR Plugin load failed: hexo-generator-feed
TypeError: Object.assignn is not a function
```