### PR TITLE
chore(package): delete jscs & use eslint

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "excludeFiles": ["node_modules/**", "coverage/**", "tmp/**"],
-  "preset": "hexo"
-}

--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,3 @@ appveyor.yml
 .npmignore
 package-lock.json
 yarn.lock
-.jscsrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ node_js:
 
 script:
   - npm run eslint
-  - npm run jscs
   - npm run test-cov
 
 after_script:

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,14 +4,14 @@ var nunjucks = require('nunjucks');
 var env = new nunjucks.Environment();
 var pathFn = require('path');
 var fs = require('fs');
-var gravatar = require('hexo/lib/plugins/helper/gravatar');
+var gravatar = require('hexo/lib/plugins/helper/gravatar'); // eslint-disable-line node/no-unpublished-require
 
 env.addFilter('uriencode', function(str) {
   return encodeURI(str);
 });
 
 env.addFilter('noControlChars', function(str) {
-  return str.replace(/[\x00-\x1F\x7F]/g, '');
+  return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
 });
 
 var atomTmplSrc = pathFn.join(__dirname, '../atom.xml');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index",
   "scripts": {
     "eslint": "eslint .",
-    "jscs": "jscs .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -39,12 +38,10 @@
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "cheerio": "^0.22.0",
-    "eslint": "^2.4.0",
-    "eslint-config-hexo": "^1.0.4",
+    "eslint": "^5.13.0",
+    "eslint-config-hexo": "^3.0.0",
     "hexo": "^3.3.1",
     "istanbul": "^0.4.5",
-    "jscs": "^3.0.7",
-    "jscs-preset-hexo": "^1.0.1",
     "mocha": "^5.2.0"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ env.addFilter('uriencode', function(str) {
 });
 
 env.addFilter('noControlChars', function(str) {
-  return str.replace(/[\x00-\x1F\x7F]/g, '');
+  return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
 });
 
 var atomTmplSrc = pathFn.join(__dirname, '../atom.xml');
@@ -33,10 +33,10 @@ describe('Feed generator', function() {
   var Post = hexo.model('Post');
   var generator = require('../lib/generator').bind(hexo);
 
-  (require('../node_modules/hexo/lib/plugins/helper'))(hexo);
+  require('../node_modules/hexo/lib/plugins/helper')(hexo);
 
-  var posts;
-  var locals;
+  var posts,
+    locals;
 
   before(function() {
     return Post.insert([
@@ -113,7 +113,7 @@ describe('Feed generator', function() {
     var result = generator(locals);
     var $ = cheerio.load(result.data, {xmlMode: true});
 
-    var description = $('content\\\:encoded').html()
+    var description = $('content\\:encoded').html()
       .replace(/^<!\[CDATA\[/, '')
       .replace(/\]\]>$/, '');
 


### PR DESCRIPTION
[jscs has already merged with eslint](https://www.npmjs.com/package/jscs). 

## fix ESLint  error

I fix 6 eslint error after migrate to eslint.

```sh
$ yarn eslint
$ eslint .

./hexo-generator-feed/lib/generator.js
   7:24  error  "hexo" is not published                                            node/no-unpublished-require
  14:22  error  Unexpected control character(s) in regular expression: \x00, \x1f  no-control-regex

./hexo-generator-feed/test/index.js
   16:22  error  Unexpected control character(s) in regular expression: \x00, \x1f            no-control-regex
   36:3   error  Unnecessary parentheses around expression                                    no-extra-parens
   39:3   error  Combine this with the previous 'var' statement with uninitialized variables  one-var
  116:35  error  Unnecessary escape character: \:                                             no-useless-escape

✖ 6 problems (6 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```