### PR TITLE
fix(IDN): uriencode root value

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -5,9 +5,9 @@
   {% if config.subtitle %}<subtitle>{{ config.subtitle }}</subtitle>{% endif %}
   <link href="{{ feed_url | uriencode }}" rel="self"/>
   {% if config.feed.hub %}<link href="{{ config.feed.hub | uriencode }}" rel="hub"/>{% endif %}
-  <link href="{{ url }}"/>
+  <link href="{{ url | uriencode }}"/>
   <updated>{{ posts.first().updated.toISOString() }}</updated>
-  <id>{{ url }}</id>
+  <id>{{ url | uriencode }}</id>
   {% if config.author %}
   <author>
     <name>{{ config.author }}</name>
@@ -18,8 +18,8 @@
   {% for post in posts.toArray() %}
   <entry>
     <title>{{ post.title }}</title>
-    <link href="{{ url }}{{ post.path | uriencode }}"/>
-    <id>{{ url }}{{ post.path }}</id>
+    <link href="{{ post.permalink | uriencode }}"/>
+    <id>{{ post.permalink | uriencode }}</id>
     <published>{{ post.date.toISOString() }}</published>
     <updated>{{ post.updated.toISOString() }}</updated>
     {% if config.feed.content and post.content %}
@@ -47,13 +47,13 @@
     {% endif %}
     </summary>
     {% if post.image %}
-    <content src="{{ url }}{{ post.image | uriencode }}" type="image" />
+    <content src="{{ url + post.image | uriencode }}" type="image" />
     {% endif %}
     {% for category in post.categories.toArray() %}
-      <category term="{{ category.name }}" scheme="{{ url }}{{ category.path | uriencode }}"/>
+      <category term="{{ category.name }}" scheme="{{ url + category.path | uriencode }}"/>
     {% endfor %}
     {% for tag in post.tags.toArray() %}
-      <category term="{{ tag.name }}" scheme="{{ url }}{{ tag.path | uriencode }}"/>
+      <category term="{{ tag.name }}" scheme="{{ url + tag.path | uriencode }}"/>
     {% endfor %}
   </entry>
   {% endfor %}

--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="https://www.w3.org/2005/Atom">
   <title>{{ config.title }}</title>
   {% if icon %}<icon>{{ icon }}</icon>{% endif %}
   {% if config.subtitle %}<subtitle>{{ config.subtitle }}</subtitle>{% endif %}
@@ -14,7 +14,7 @@
     {% if config.email %}<email>{{ config.email }}</email>{% endif %}
   </author>
   {% endif %}
-  <generator uri="http://hexo.io/">Hexo</generator>
+  <generator uri="https://hexo.io/">Hexo</generator>
   {% for post in posts.toArray() %}
   <entry>
     <title>{{ post.title }}</title>

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,10 +4,10 @@ const nunjucks = require('nunjucks');
 const env = new nunjucks.Environment();
 const { join } = require('path');
 const { readFileSync } = require('fs');
-const { gravatar } = require('hexo-util');
+const { encodeURL, gravatar } = require('hexo-util');
 
 env.addFilter('uriencode', str => {
-  return encodeURI(str);
+  return encodeURL(str);
 });
 
 env.addFilter('noControlChars', str => {

--- a/rss2.xml
+++ b/rss2.xml
@@ -13,8 +13,8 @@
     {% for post in posts.toArray() %}
     <item>
       <title>{{ post.title }}</title>
-      <link>{{ url }}{{ post.path | uriencode }}</link>
-      <guid>{{ url }}{{ post.path | uriencode }}</guid>
+      <link>{{ post.permalink | uriencode }}</link>
+      <guid>{{ post.permalink | uriencode }}</guid>
       <pubDate>{{ post.date.toDate().toUTCString() }}</pubDate>
       <description>
       {% if post.description %}
@@ -38,12 +38,12 @@
       {% endif %}
       </description>
       {% if post.image %}
-      <enclosure url="{{ url + post.image }}" type="image" />
+      <enclosure url="{{ url + post.image | uriencode }}" type="image" />
       {% endif %}
       {% if config.feed.content and post.content %}
       <content:encoded><![CDATA[{{ post.content | noControlChars | safe }}]]></content:encoded>
       {% endif %}
-      {% if post.comments %}<comments>{{ url }}{{ post.path | uriencode }}#disqus_thread</comments>{% endif %}
+      {% if post.comments %}<comments>{{ post.permalink | uriencode }}#disqus_thread</comments>{% endif %}
     </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
The current approach does not encode the root value, this PR fixes that.
Similar to https://github.com/hexojs/hexo-generator-sitemap/pull/66

This PR is necessary to be compatible with hexo v4 and v3 or older (forward & backward compatibility).

Supersede #88 