### PR TITLE
refactor: use gravatar from hexo-util

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,7 +4,7 @@ const nunjucks = require('nunjucks');
 const env = new nunjucks.Environment();
 const { join } = require('path');
 const { readFileSync } = require('fs');
-const gravatar = require('hexo/lib/plugins/helper/gravatar'); // eslint-disable-line node/no-unpublished-require
+const { gravatar } = require('hexo-util');
 
 env.addFilter('uriencode', str => {
   return encodeURI(str);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "hexo-util": "^1.3.0",
     "nunjucks": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[`gravatar()`](https://github.com/hexojs/hexo-util/pull/81) is available on hexo-util [1.2.0](https://github.com/hexojs/hexo-util/releases/tag/1.2.0).