### PR TITLE
feat: add rss autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ feed:
   content_limit: 140
   content_limit_delim: ' '
   order_by: -date
-  icon: icon.png
+  icon: icon.png,
+  autodiscovery: true
 ```
 
 - **type** - Feed type. (atom/rss2)
@@ -45,3 +46,5 @@ feed:
 - **content_limit_delim** - (optional) If **content_limit** is used to shorten post contents, only cut at the last occurrence of this delimiter before reaching the character limit. Not used by default.
 - **order_by** - Feed order-by. (Default: -date)
 - **icon** - (optional) Custom feed icon. Defaults to a gravatar of email specified in the main config.
+- **autodiscovery** - Add feed [autodiscovery](http://www.rssboard.org/rss-autodiscovery). (Default: `true`)
+  * Many themes already offer this feature, so you may also need to adjust the theme's config if you wish to disable it.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ feed:
   content_limit: 140
   content_limit_delim: ' '
   order_by: -date
-  icon: icon.png,
+  icon: icon.png
   autodiscovery: true
 ```
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,6 @@ if (!extname(config.path)) {
 
 hexo.extend.generator.register('feed', require('./lib/generator'));
 
-if (hexo.config.feed.autodiscovery === true) {
+if (config.autodiscovery === true) {
   hexo.extend.filter.register('after_render:html', require('./lib/autodiscovery'));
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const config = hexo.config.feed = Object.assign({
   content: true,
   content_limit: 140,
   content_limit_delim: '',
-  order_by: '-date'
+  order_by: '-date',
+  autodiscovery: true
 }, hexo.config.feed);
 
 const type = config.type.toLowerCase();
@@ -33,3 +34,7 @@ if (!extname(config.path)) {
 }
 
 hexo.extend.generator.register('feed', require('./lib/generator'));
+
+if (hexo.config.feed.autodiscovery === true) {
+  hexo.extend.filter.register('after_render:html', require('./lib/autodiscovery'));
+}

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function autodiscoveryInject(data) {
+  const { config } = this;
+  const { feed } = config;
+  const type = feed.type.replace(/2$/, '');
+
+  if (!feed.autodiscovery
+    || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
+
+  const autodiscoveryTag = `<link rel="alternate" href="${feed.path}" title="${config.title}" type="application/${type}+xml">`;
+
+  return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${autodiscoveryTag}</head>`));
+}
+
+module.exports = autodiscoveryInject;

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
@@ -8,7 +10,7 @@ function autodiscoveryInject(data) {
   if (!feed.autodiscovery
     || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
-  const autodiscoveryTag = `<link rel="alternate" href="${feed.path}" title="${config.title}" type="application/${type}+xml">`;
+  const autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
 
   return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${autodiscoveryTag}</head>`));
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "hexo-util": "^1.3.0",
     "nunjucks": "^3.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -252,10 +252,22 @@ describe('Autodiscovery', () => {
 
     const $ = cheerio.load(result);
     $('link[type="application/atom+xml"]').length.should.eql(1);
-    $('link[type="application/atom+xml"]').attr('href').should.eql(hexo.config.feed.path);
+    $('link[type="application/atom+xml"]').attr('href').should.eql('/' + hexo.config.feed.path);
     $('link[type="application/atom+xml"]').attr('title').should.eql(hexo.config.title);
 
-    result.should.eql('<head><link><link rel="alternate" href="atom.xml" title="foo" type="application/atom+xml"></head>');
+    result.should.eql('<head><link><link rel="alternate" href="/atom.xml" title="foo" type="application/atom+xml"></head>');
+  });
+
+  it('prepend root', () => {
+    hexo.config.root = '/root/';
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const $ = cheerio.load(result);
+    $('link[type="application/atom+xml"]').attr('href').should.eql(hexo.config.root + hexo.config.feed.path);
+
+    result.should.eql('<head><link><link rel="alternate" href="/root/atom.xml" title="foo" type="application/atom+xml"></head>');
+    hexo.config.root = '/';
   });
 
   it('disable autodiscovery', () => {
@@ -270,7 +282,7 @@ describe('Autodiscovery', () => {
 
   it('no duplicate tag', () => {
     const content = '<head><link>'
-      + '<link rel="alternate" href="atom.xml" title="foo" type="application/atom+xml"></head>';
+      + '<link rel="alternate" href="/atom.xml" title="foo" type="application/atom+xml"></head>';
     const result = autoDiscovery(content);
 
     const resultType = typeof result;
@@ -287,7 +299,7 @@ describe('Autodiscovery', () => {
     $('link[type="application/atom+xml"]').length.should.eql(1);
 
     const expected = '<head></head>'
-    + '<head><link><link rel="alternate" href="atom.xml" title="foo" type="application/atom+xml"></head>'
+    + '<head><link><link rel="alternate" href="/atom.xml" title="foo" type="application/atom+xml"></head>'
     + '<head></head>';
     result.should.eql(expected);
   });
@@ -302,7 +314,7 @@ describe('Autodiscovery', () => {
     $('link[type="application/atom+xml"]').length.should.eql(1);
 
     const expected = '<head></head>'
-    + '<head><link><link rel="alternate" href="atom.xml" title="foo" type="application/atom+xml"></head>'
+    + '<head><link><link rel="alternate" href="/atom.xml" title="foo" type="application/atom+xml"></head>'
     + '<head><link></head>';
     result.should.eql(expected);
   });
@@ -319,7 +331,7 @@ describe('Autodiscovery', () => {
     const $ = cheerio.load(result);
     $('link[rel="alternate"]').attr('type').should.eql('application/rss+xml');
 
-    result.should.eql('<head><link><link rel="alternate" href="rss2.xml" title="foo" type="application/rss+xml"></head>');
+    result.should.eql('<head><link><link rel="alternate" href="/rss2.xml" title="foo" type="application/rss+xml"></head>');
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -236,7 +236,7 @@ describe('Feed generator', () => {
   });
 });
 
-describe('Meta Generator', () => {
+describe('Autodiscovery', () => {
   const hexo = new Hexo();
   const autoDiscovery = require('../lib/autodiscovery').bind(hexo);
   hexo.config.title = 'foo';


### PR DESCRIPTION
Many (most?) themes already offer this feature, but this plugin should've added it in the first place.

ref: http://www.rssboard.org/rss-autodiscovery
credit: [meta_generator.js](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/meta_generator.js)