### PR TITLE
feat: support output in both atom and rss2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ feed:
 ```
 
 - **type** - Feed type. `atom` or `rss2`. Specify `['atom', 'rss2']` to output both types. (Default: `atom`)
+  * Example:
+  ``` yaml
+  feed:
+    # Generate atom feed
+    type: atom
+
+    # Generate both atom and rss2 feeds
+    type:
+      - atom
+      - rss2
+    path:
+      - atom.xml
+      - rss2.xml
+  ```
 - **path** - Feed path. When both types are specified, path must follow the order of type value. (Default: atom.xml/rss2.xml)
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts)
 - **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ feed:
   autodiscovery: true
 ```
 
-- **type** - Feed type. (atom/rss2)
-- **path** - Feed path. (Default: atom.xml/rss2.xml)
+- **type** - Feed type. `atom` or `rss2`. Specify `['atom', 'rss2']` to output both types. (Default: `atom`)
+- **path** - Feed path. When both types are specified, path must follow the order of type value. (Default: atom.xml/rss2.xml)
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts)
 - **hub** - URL of the PubSubHubbub hubs (Leave it empty if you don't use it)
 - **content** - (optional) set to 'true' to include the contents of the entire post in the feed.

--- a/index.js
+++ b/index.js
@@ -40,24 +40,18 @@ if (typeof type === 'string') {
     return feedFn.call(hexo, locals);
   });
 } else {
-  type = type.map(str => str.toLowerCase());
+  if (!type) type = ['atom', 'rss2'];
 
-  if (type.length === 1) {
-    if (type[0] === 'atom') type.push('rss2');
-    else if (type[0] === 'rss2') type.push('atom');
-    else {
-      type[0] = 'atom';
-      type.push('rss2');
-    }
+  if (!Array.isArray(type)) type = ['atom', 'rss2'];
+  else if (!type.includes('atom') || !type.includes('rss2')
+    || type.length !== 2) {
+    type = ['atom', 'rss2'];
   }
 
   if (!path) path = type.map(str => str.concat('.xml'));
 
-  if (typeof path === 'string') path = [path];
-
-  if (path.length === 1) {
-    if (path[0].toLowerCase().includes('atom')) path.push('rss2.xml');
-    else path.push('atom.xml');
+  if (!Array.isArray(path) || path.length !== 2) {
+    path = type.map(str => str.concat('.xml'));
   }
 
   path = path.map(str => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* global hexo */
 'use strict';
 
+const { extname } = require('path');
+
 const config = hexo.config.feed = Object.assign({
   type: 'atom',
   limit: 20,
@@ -13,6 +15,7 @@ const config = hexo.config.feed = Object.assign({
 }, hexo.config.feed);
 
 let type = config.type;
+let path = config.path;
 const feedFn = require('./lib/generator');
 
 if (typeof type === 'string') {
@@ -23,20 +26,47 @@ if (typeof type === 'string') {
     type = 'atom';
   }
 
+  if (!path) path = type.concat('.xml');
+
+  // Add extension name if not found
+  if (!extname(path)) {
+    path += '.xml';
+  }
+
   config.type = type;
+  config.path = path;
 
   hexo.extend.generator.register('feed', function(locals) {
-    return feedFn.call(hexo, locals, type);
+    return feedFn.call(hexo, locals);
   });
 } else {
   type = type.map(str => str.toLowerCase());
 
   if (type.length === 1) {
     if (type[0] === 'atom') type.push('rss2');
-    else type.push('atom');
+    else if (type[0] === 'rss2') type.push('atom');
+    else {
+      type[0] = 'atom';
+      type.push('rss2');
+    }
   }
 
+  if (!path) path = type.map(str => str.concat('.xml'));
+
+  if (typeof path === 'string') path = [path];
+
+  if (path.length === 1) {
+    if (path[0].toLowerCase().includes('atom')) path.push('rss2.xml');
+    else path.push('atom.xml');
+  }
+
+  path = path.map(str => {
+    if (!extname(str)) return str.concat('.xml');
+    return str;
+  });
+
   config.type = type;
+  config.path = path;
 
   hexo.extend.generator.register('feed1', function(locals) {
     return feedFn.call(hexo, locals, type[0]);

--- a/index.js
+++ b/index.js
@@ -40,8 +40,6 @@ if (!type || typeof type === 'string') {
     return feedFn.call(hexo, locals);
   });
 } else {
-  if (!type) type = ['atom', 'rss2'];
-
   if (!Array.isArray(type)) type = ['atom', 'rss2'];
   else if (!type.includes('atom') || !type.includes('rss2')
     || type.length !== 2) {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ if (type.length === 2) {
   });
 }
 
+if (typeof config.autodiscovery === 'undefined') config.autodiscovery = true;
+
 if (config.autodiscovery === true) {
   hexo.extend.filter.register('after_render:html', require('./lib/autodiscovery'));
 }

--- a/index.js
+++ b/index.js
@@ -18,15 +18,15 @@ let type = config.type;
 let path = config.path;
 const feedFn = require('./lib/generator');
 
-if (typeof type === 'string') {
-  type = type.toLowerCase();
+if (!type || typeof type === 'string') {
+  if (!type) type = 'atom';
 
   // Check feed type
   if (type !== 'atom' && type !== 'rss2') {
     type = 'atom';
   }
 
-  if (!path) path = type.concat('.xml');
+  if (!path || typeof path !== 'string') path = type.concat('.xml');
 
   // Add extension name if not found
   if (!extname(path)) {

--- a/index.js
+++ b/index.js
@@ -53,13 +53,9 @@ path = path.map(str => {
 config.type = type;
 config.path = path;
 
-hexo.extend.generator.register('feed1', locals => {
-  return feedFn.call(hexo, locals, type[0], path[0]);
-});
-
-if (type.length === 2) {
-  hexo.extend.generator.register('feed2', locals => {
-    return feedFn.call(hexo, locals, type[1], path[1]);
+for (const feedType of type) {
+  hexo.extend.generator.register(feedType, locals => {
+    return feedFn.call(hexo, locals, feedType, path[type.indexOf(feedType)]);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ let type = config.type;
 let path = config.path;
 const feedFn = require('./lib/generator');
 
-if (!type || typeof type === 'string' || !Array.isArray(type)) {
+if (typeof type === 'string') type = [type];
+
+if (!type || !Array.isArray(type)) {
   type = ['atom'];
 }
 

--- a/index.js
+++ b/index.js
@@ -18,54 +18,43 @@ let type = config.type;
 let path = config.path;
 const feedFn = require('./lib/generator');
 
-if (!type || typeof type === 'string') {
-  if (!type) type = 'atom';
+if (!type || typeof type === 'string' || !Array.isArray(type)) {
+  type = ['atom'];
+}
 
-  // Check feed type
-  if (type !== 'atom' && type !== 'rss2') {
-    type = 'atom';
+if (Array.isArray(type) && type.length > 2) {
+  type = type.slice(0, 2);
+}
+
+type = type.map((str, i) => {
+  str = str.toLowerCase();
+  if (str !== 'atom' && str !== 'rss2') {
+    if (i === 0) str = 'atom';
+    else str = 'rss2';
   }
+  return str;
+});
 
-  if (!path || typeof path !== 'string') path = type.concat('.xml');
+if (!path || typeof path === 'string' || !Array.isArray(path)) {
+  path = type.map(str => str.concat('.xml'));
+}
 
-  // Add extension name if not found
-  if (!extname(path)) {
-    path += '.xml';
-  }
+if (Array.isArray(path) && path.length > 2) {
+  path = path.slice(0, 2);
+}
 
-  config.type = type;
-  config.path = path;
+path = path.map(str => {
+  if (!extname(str)) return str.concat('.xml');
+  return str;
+});
 
-  hexo.extend.generator.register('feed', function(locals) {
-    return feedFn.call(hexo, locals);
-  });
-} else {
-  if (!Array.isArray(type)) type = ['atom', 'rss2'];
-  else if (!type.includes('atom') || !type.includes('rss2')
-    || type.length !== 2) {
-    type = ['atom', 'rss2'];
-  }
+hexo.extend.generator.register('feed1', locals => {
+  return feedFn.call(hexo, locals, type[0], path[0]);
+});
 
-  if (!path) path = type.map(str => str.concat('.xml'));
-
-  if (!Array.isArray(path) || path.length !== 2) {
-    path = type.map(str => str.concat('.xml'));
-  }
-
-  path = path.map(str => {
-    if (!extname(str)) return str.concat('.xml');
-    return str;
-  });
-
-  config.type = type;
-  config.path = path;
-
-  hexo.extend.generator.register('feed1', function(locals) {
-    return feedFn.call(hexo, locals, type[0]);
-  });
-
-  hexo.extend.generator.register('feed2', function(locals) {
-    return feedFn.call(hexo, locals, type[1]);
+if (type.length === 2) {
+  hexo.extend.generator.register('feed2', locals => {
+    return feedFn.call(hexo, locals, type[1], path[1]);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 /* global hexo */
 'use strict';
 
-const { extname } = require('path');
-
 const config = hexo.config.feed = Object.assign({
   type: 'atom',
   limit: 20,
@@ -14,26 +12,31 @@ const config = hexo.config.feed = Object.assign({
   autodiscovery: true
 }, hexo.config.feed);
 
-const type = config.type.toLowerCase();
+let type = config.type;
+const feedFn = require('./lib/generator');
 
-// Check feed type
-if (type !== 'atom' && type !== 'rss2') {
-  config.type = 'atom';
-} else {
+if (typeof type === 'string') {
+  type = type.toLowerCase();
+
+  // Check feed type
+  if (type !== 'atom' && type !== 'rss2') {
+    type = 'atom';
+  }
+
   config.type = type;
-}
 
-// Set default feed path
-if (!config.path) {
-  config.path = config.type + '.xml';
-}
+  hexo.extend.generator.register('feed', function(locals) {
+    return feedFn.call(hexo, locals, type);
+  });
+} else {
+  hexo.extend.generator.register('feed1', function(locals) {
+    return feedFn.call(hexo, locals, type[0]);
+  });
 
-// Add extension name if don't have
-if (!extname(config.path)) {
-  config.path += '.xml';
+  hexo.extend.generator.register('feed2', function(locals) {
+    return feedFn.call(hexo, locals, type[1]);
+  });
 }
-
-hexo.extend.generator.register('feed', require('./lib/generator'));
 
 if (config.autodiscovery === true) {
   hexo.extend.filter.register('after_render:html', require('./lib/autodiscovery'));

--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ path = path.map(str => {
   return str;
 });
 
+config.type = type;
+config.path = path;
+
 hexo.extend.generator.register('feed1', locals => {
   return feedFn.call(hexo, locals, type[0], path[0]);
 });

--- a/index.js
+++ b/index.js
@@ -29,6 +29,15 @@ if (typeof type === 'string') {
     return feedFn.call(hexo, locals, type);
   });
 } else {
+  type = type.map(str => str.toLowerCase());
+
+  if (type.length === 1) {
+    if (type[0] === 'atom') type.push('rss2');
+    else type.push('atom');
+  }
+
+  config.type = type;
+
   hexo.extend.generator.register('feed1', function(locals) {
     return feedFn.call(hexo, locals, type[0]);
   });

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -1,16 +1,39 @@
 'use strict';
 
+const { extname } = require('path');
 const { url_for } = require('hexo-util');
 
 function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
-  const type = feed.type.replace(/2$/, '');
+  let type = feed.type;
+  let autodiscoveryTag, path;
 
   if (!feed.autodiscovery
     || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
-  const autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
+  if (typeof type === 'string') {
+    type = type.replace(/2$/, '');
+    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
+  } else {
+    if (Array.isArray(feed.path)) {
+      path = feed.path;
+    } else {
+      path = type;
+    }
+
+    path = path.map(str => {
+      if (!extname(str)) {
+        return str.concat('.xml');
+      }
+      return str;
+    });
+
+    type = type.map(str => str.replace(/2$/, ''));
+
+    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, path[0])}" title="${config.title}" type="application/${type[0]}+xml">`;
+    autodiscoveryTag += `\n<link rel="alternate" href="${url_for.call(this, path[1])}" title="${config.title}" type="application/${type[1]}+xml">`;
+  }
 
   return data.replace(/<head>(?!<\/head>).+?<\/head>/s, (str) => str.replace('</head>', `${autodiscoveryTag}</head>`));
 }

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -29,8 +29,6 @@ function autodiscoveryInject(data) {
     type = type.replace(/2$/, '');
     autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, path)}" title="${config.title}" type="application/${type}+xml">`;
   } else {
-    if (!type) type = ['atom', 'rss2'];
-
     if (!Array.isArray(type)) type = ['atom', 'rss2'];
     else if (!type.includes('atom') || !type.includes('rss2')
       || type.length !== 2) {

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -10,7 +10,9 @@ function autodiscoveryInject(data) {
   let path = feed.path
   let autodiscoveryTag;
 
-  if (!feed.autodiscovery
+  if (typeof feed.autodiscovery === 'undefined') feed.autodiscovery = true;
+
+  if (feed.autodiscovery === false
     || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
   if (!type || typeof type === 'string') {

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -16,24 +16,18 @@ function autodiscoveryInject(data) {
     type = type.replace(/2$/, '');
     autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
   } else {
-    type = type.map(str => str.toLowerCase());
+    if (!type) type = ['atom', 'rss2'];
 
-    if (type.length === 1) {
-      if (type[0] === 'atom') type.push('rss');
-      else if (type[0] === 'rss2') type.push('atom');
-      else {
-        type[0] = 'atom';
-        type.push('rss');
-      }
+    if (!Array.isArray(type)) type = ['atom', 'rss2'];
+    else if (!type.includes('atom') || !type.includes('rss2')
+      || type.length !== 2) {
+      type = ['atom', 'rss2'];
     }
 
     if (!path) path = type.map(str => str.concat('.xml'));
 
-    if (typeof path === 'string') path = [path];
-
-    if (path.length === 1) {
-      if (path[0].toLowerCase().includes('atom')) path.push('rss2.xml');
-      else path.push('atom.xml');
+    if (!Array.isArray(path) || path.length !== 2) {
+      path = type.map(str => str.concat('.xml'));
     }
 
     path = path.map(str => {

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -7,7 +7,7 @@ function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
   let type = feed.type;
-  let path = feed.path
+  let path = feed.path;
   let autodiscoveryTag;
 
   if (typeof feed.autodiscovery === 'undefined') feed.autodiscovery = true;

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -10,10 +10,7 @@ function autodiscoveryInject(data) {
   let path = feed.path;
   let autodiscoveryTag;
 
-  if (typeof feed.autodiscovery === 'undefined') feed.autodiscovery = true;
-
-  if (feed.autodiscovery === false
-    || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
+  if (data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
   if (!type || typeof type === 'string') {
     if (!type) type = 'atom';

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -7,14 +7,27 @@ function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
   let type = feed.type;
-  let autodiscoveryTag, path;
+  let path = feed.path
+  let autodiscoveryTag;
 
   if (!feed.autodiscovery
     || data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
-  if (typeof type === 'string') {
+  if (!type || typeof type === 'string') {
+    if (!type) type = 'atom';
+
+    if (type !== 'atom' && type !== 'rss2') {
+      type = 'atom';
+    }
+
+    if (!path || typeof path !== 'string') path = type.concat('.xml');
+
+    if (!extname(path)) {
+      path += '.xml';
+    }
+
     type = type.replace(/2$/, '');
-    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
+    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, path)}" title="${config.title}" type="application/${type}+xml">`;
   } else {
     if (!type) type = ['atom', 'rss2'];
 

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -16,16 +16,28 @@ function autodiscoveryInject(data) {
     type = type.replace(/2$/, '');
     autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${config.title}" type="application/${type}+xml">`;
   } else {
-    if (Array.isArray(feed.path)) {
-      path = feed.path;
-    } else {
-      path = type;
+    type = type.map(str => str.toLowerCase());
+
+    if (type.length === 1) {
+      if (type[0] === 'atom') type.push('rss');
+      else if (type[0] === 'rss2') type.push('atom');
+      else {
+        type[0] = 'atom';
+        type.push('rss');
+      }
+    }
+
+    if (!path) path = type.map(str => str.concat('.xml'));
+
+    if (typeof path === 'string') path = [path];
+
+    if (path.length === 1) {
+      if (path[0].toLowerCase().includes('atom')) path.push('rss2.xml');
+      else path.push('atom.xml');
     }
 
     path = path.map(str => {
-      if (!extname(str)) {
-        return str.concat('.xml');
-      }
+      if (!extname(str)) return str.concat('.xml');
       return str;
     });
 

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -1,55 +1,20 @@
 'use strict';
 
-const { extname } = require('path');
 const { url_for } = require('hexo-util');
 
 function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
-  let type = feed.type;
-  let path = feed.path;
-  let autodiscoveryTag;
+  const type = feed.type;
+  const path = feed.path;
+  let autodiscoveryTag = '';
 
   if (data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
 
-  if (!type || typeof type === 'string') {
-    if (!type) type = 'atom';
-
-    if (type !== 'atom' && type !== 'rss2') {
-      type = 'atom';
-    }
-
-    if (!path || typeof path !== 'string') path = type.concat('.xml');
-
-    if (!extname(path)) {
-      path += '.xml';
-    }
-
-    type = type.replace(/2$/, '');
-    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, path)}" title="${config.title}" type="application/${type}+xml">`;
-  } else {
-    if (!Array.isArray(type)) type = ['atom', 'rss2'];
-    else if (!type.includes('atom') || !type.includes('rss2')
-      || type.length !== 2) {
-      type = ['atom', 'rss2'];
-    }
-
-    if (!path) path = type.map(str => str.concat('.xml'));
-
-    if (!Array.isArray(path) || path.length !== 2) {
-      path = type.map(str => str.concat('.xml'));
-    }
-
-    path = path.map(str => {
-      if (!extname(str)) return str.concat('.xml');
-      return str;
-    });
-
-    type = type.map(str => str.replace(/2$/, ''));
-
-    autodiscoveryTag = `<link rel="alternate" href="${url_for.call(this, path[0])}" title="${config.title}" type="application/${type[0]}+xml">`;
-    autodiscoveryTag += `\n<link rel="alternate" href="${url_for.call(this, path[1])}" title="${config.title}" type="application/${type[1]}+xml">`;
-  }
+  type.forEach((feedType, i) => {
+    autodiscoveryTag += `<link rel="alternate" href="${url_for.call(this, path[i])}" `
+      + `title="${config.title}" type="application/${feedType.replace(/2$/, '')}+xml">\n`;
+  });
 
   return data.replace(/<head>(?!<\/head>).+?<\/head>/s, (str) => str.replace('</head>', `${autodiscoveryTag}</head>`));
 }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -19,20 +19,10 @@ const atomTmpl = nunjucks.compile(readFileSync(atomTmplSrc, 'utf8'), env);
 const rss2TmplSrc = join(__dirname, '../rss2.xml');
 const rss2Tmpl = nunjucks.compile(readFileSync(rss2TmplSrc, 'utf8'), env);
 
-module.exports = function(locals, type) {
+module.exports = function(locals, type, path) {
   const config = this.config;
   const feedConfig = config.feed;
-  let path = feedConfig.path;
-  let template;
-
-  if (!type) type = feedConfig.type;
-
-  if (type === 'atom') template = atomTmpl;
-  else template = rss2Tmpl;
-
-  if (Array.isArray(path)) {
-    path = path[feedConfig.type.indexOf(type)];
-  }
+  const template = type === 'atom' ? atomTmpl : rss2Tmpl;
 
   let posts = locals.posts.sort(feedConfig.order_by || '-date');
   posts = posts.filter(post => {
@@ -57,7 +47,7 @@ module.exports = function(locals, type) {
   });
 
   return {
-    path: path,
+    path,
     data: xml
   };
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,7 +2,7 @@
 
 const nunjucks = require('nunjucks');
 const env = new nunjucks.Environment();
-const { join } = require('path');
+const { extname, join } = require('path');
 const { readFileSync } = require('fs');
 const { encodeURL, gravatar, full_url_for } = require('hexo-util');
 
@@ -19,10 +19,20 @@ const atomTmpl = nunjucks.compile(readFileSync(atomTmplSrc, 'utf8'), env);
 const rss2TmplSrc = join(__dirname, '../rss2.xml');
 const rss2Tmpl = nunjucks.compile(readFileSync(rss2TmplSrc, 'utf8'), env);
 
-module.exports = function(locals) {
+module.exports = function(locals, type) {
   const config = this.config;
   const feedConfig = config.feed;
-  const template = feedConfig.type === 'rss2' ? rss2Tmpl : atomTmpl;
+  const template = type === 'rss2' ? rss2Tmpl : atomTmpl;
+  let path = feedConfig.path ? feedConfig.path : type.concat('.xml');
+
+  if (Array.isArray(path)) {
+    path = path[feedConfig.type.indexOf(type)]
+  }
+
+  // Add extension name if don't have
+  if (!extname(path)) {
+    path += '.xml';
+  }
 
   let posts = locals.posts.sort(feedConfig.order_by || '-date');
   posts = posts.filter(post => {
@@ -43,11 +53,11 @@ module.exports = function(locals) {
     url,
     icon,
     posts,
-    feed_url: config.root + feedConfig.path
+    feed_url: config.root + path
   });
 
   return {
-    path: feedConfig.path,
+    path: path,
     data: xml
   };
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -26,7 +26,7 @@ module.exports = function(locals, type) {
   let path = feedConfig.path ? feedConfig.path : type.concat('.xml');
 
   if (Array.isArray(path)) {
-    path = path[feedConfig.type.indexOf(type)]
+    path = path[feedConfig.type.indexOf(type)];
   }
 
   // Add extension name if don't have

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,7 +2,7 @@
 
 const nunjucks = require('nunjucks');
 const env = new nunjucks.Environment();
-const { extname, join } = require('path');
+const { join } = require('path');
 const { readFileSync } = require('fs');
 const { encodeURL, gravatar, full_url_for } = require('hexo-util');
 
@@ -22,16 +22,16 @@ const rss2Tmpl = nunjucks.compile(readFileSync(rss2TmplSrc, 'utf8'), env);
 module.exports = function(locals, type) {
   const config = this.config;
   const feedConfig = config.feed;
-  const template = type === 'rss2' ? rss2Tmpl : atomTmpl;
-  let path = feedConfig.path ? feedConfig.path : type.concat('.xml');
+  let path = feedConfig.path;
+  let template;
+
+  if (!type) type = feedConfig.type;
+
+  if (type === 'atom') template = atomTmpl;
+  else template = rss2Tmpl;
 
   if (Array.isArray(path)) {
     path = path[feedConfig.type.indexOf(type)];
-  }
-
-  // Add extension name if don't have
-  if (!extname(path)) {
-    path += '.xml';
   }
 
   let posts = locals.posts.sort(feedConfig.order_by || '-date');

--- a/test/index.js
+++ b/test/index.js
@@ -323,8 +323,7 @@ describe('Autodiscovery', () => {
   hexo.config.title = 'foo';
   hexo.config.feed = {
     type: 'atom',
-    path: 'atom.xml',
-    autodiscovery: true
+    path: 'atom.xml'
   };
   hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -351,16 +350,6 @@ describe('Autodiscovery', () => {
 
     result.should.eql('<head><link><link rel="alternate" href="/root/atom.xml" title="foo" type="application/atom+xml"></head>');
     hexo.config.root = '/';
-  });
-
-  it('disable autodiscovery', () => {
-    hexo.config.feed.autodiscovery = false;
-    const content = '<head><link></head>';
-    const result = autoDiscovery(content);
-
-    const resultType = typeof result;
-    resultType.should.eql('undefined');
-    hexo.config.feed.autodiscovery = true;
   });
 
   it('no duplicate tag', () => {
@@ -405,8 +394,7 @@ describe('Autodiscovery', () => {
   it('rss2', () => {
     hexo.config.feed = {
       type: 'rss2',
-      path: 'rss2.xml',
-      autodiscovery: true
+      path: 'rss2.xml'
     };
     const content = '<head><link></head>';
     const result = autoDiscovery(content);
@@ -418,8 +406,7 @@ describe('Autodiscovery', () => {
 
     hexo.config.feed = {
       type: 'atom',
-      path: 'atom.xml',
-      autodiscovery: true
+      path: 'atom.xml'
     };
   });
 
@@ -430,24 +417,10 @@ describe('Autodiscovery', () => {
     result.should.eql('<head>\n<link>\n<link rel="alternate" href="/atom.xml" title="foo" type="application/atom+xml"></head>');
   });
 
-  it('enable by default', () => {
-    hexo.config.feed = {
-      type: 'atom',
-      path: 'atom.xml',
-      autodiscovery: undefined
-    };
-    const content = '<head><link></head>';
-    const result = autoDiscovery(content);
-    const resultType = typeof result;
-
-    resultType.should.not.eql('undefined');
-  });
-
   it('defaults to atom when type is undefined', () => {
     hexo.config.feed = {
       type: undefined,
-      path: 'atom.xml',
-      autodiscovery: true
+      path: 'atom.xml'
     };
     const content = '<head><link></head>';
     const result = autoDiscovery(content);
@@ -459,8 +432,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom when type is not atom/rss2', () => {
     hexo.config.feed = {
       type: 'foo',
-      path: 'atom.xml',
-      autodiscovery: true
+      path: 'atom.xml'
     };
     const content = '<head><link></head>';
     const result = autoDiscovery(content);
@@ -472,8 +444,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom.xml', () => {
     hexo.config.feed = {
       type: 'atom',
-      path: undefined,
-      autodiscovery: true
+      path: undefined
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -487,8 +458,7 @@ describe('Autodiscovery', () => {
   it('add xml file extension if not found', () => {
     hexo.config.feed = {
       type: 'atom',
-      path: 'atom',
-      autodiscovery: true
+      path: 'atom'
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -502,8 +472,7 @@ describe('Autodiscovery', () => {
   it('atom + rss2', () => {
     hexo.config.feed = {
       type: ['atom', 'rss2'],
-      path: ['atom.xml', 'rss2.xml'],
-      autodiscovery: true
+      path: ['atom.xml', 'rss2.xml']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -519,8 +488,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom + rss2 if type is an object', () => {
     hexo.config.feed = {
       type: { foo: 'bar' },
-      path: ['atom.xml', 'rss2.xml'],
-      autodiscovery: true
+      path: ['atom.xml', 'rss2.xml']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -534,8 +502,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom + rss2 if type has invalid values', () => {
     hexo.config.feed = {
       type: ['foo', 'bar'],
-      path: ['atom.xml', 'rss2.xml'],
-      autodiscovery: true
+      path: ['atom.xml', 'rss2.xml']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -549,8 +516,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom.xml + rss2.xml if type is undefined', () => {
     hexo.config.feed = {
       type: ['atom', 'rss2'],
-      path: undefined,
-      autodiscovery: true
+      path: undefined
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -565,8 +531,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom.xml + rss2.xml if type is an object', () => {
     hexo.config.feed = {
       type: ['atom', 'rss2'],
-      path: { foo: 'bar' },
-      autodiscovery: true
+      path: { foo: 'bar' }
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -581,8 +546,7 @@ describe('Autodiscovery', () => {
   it('defaults to atom.xml + rss2.xml if type has invalid values', () => {
     hexo.config.feed = {
       type: ['atom', 'rss2'],
-      path: ['foo', 'bar', 'baz'],
-      autodiscovery: true
+      path: ['foo', 'bar', 'baz']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -597,8 +561,7 @@ describe('Autodiscovery', () => {
   it('add xml file extension if not found (array)', () => {
     hexo.config.feed = {
       type: ['atom', 'rss2'],
-      path: ['atom', 'rss2'],
-      autodiscovery: true
+      path: ['atom', 'rss2']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
@@ -613,8 +576,7 @@ describe('Autodiscovery', () => {
   it('path must follow order of type', () => {
     hexo.config.feed = {
       type: ['rss2', 'atom'],
-      path: ['rss-awesome.xml', 'atom-awesome.xml'],
-      autodiscovery: true
+      path: ['rss-awesome.xml', 'atom-awesome.xml']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 

--- a/test/index.js
+++ b/test/index.js
@@ -254,7 +254,8 @@ describe('Feed generator', () => {
       icon: 'icon.svg'
     };
 
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
     const $ = cheerio.load(result.data);
 
     $('feed>icon').text().should.eql(full_url_for.call(hexo, hexo.config.feed.icon));
@@ -267,7 +268,8 @@ describe('Feed generator', () => {
       icon: undefined
     };
 
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
     const $ = cheerio.load(result.data);
 
     $('feed>icon').length.should.eql(0);
@@ -283,7 +285,8 @@ describe('Feed generator', () => {
       icon: 'icon.svg'
     };
 
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
     const $ = cheerio.load(result.data);
 
     $('rss>channel>image>url').text().should.eql(full_url_for.call(hexo, hexo.config.feed.icon));
@@ -296,7 +299,8 @@ describe('Feed generator', () => {
       icon: undefined
     };
 
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
     const $ = cheerio.load(result.data);
 
     $('rss>channel>image').length.should.eql(0);
@@ -309,10 +313,11 @@ describe('Feed generator', () => {
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 
-    const rss = generator(locals, hexo.config.feed.type[0]);
+    const feedCfg = hexo.config.feed;
+    const rss = generator(locals, feedCfg.type[0], feedCfg.path[0]);
     rss.path.should.eql(hexo.config.feed.path[0]);
 
-    const atom = generator(locals, hexo.config.feed.type[1]);
+    const atom = generator(locals, feedCfg.type[1], feedCfg.path[1]);
     atom.path.should.eql(hexo.config.feed.path[1]);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -297,7 +297,7 @@ describe('Feed generator', () => {
   it('path must follow order of type', () => {
     hexo.config.feed = {
       type: ['rss2', 'atom'],
-      path: ['rss-awesome.xml', 'atom-awesome.xml'],
+      path: ['rss-awesome.xml', 'atom-awesome.xml']
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
 

--- a/test/index.js
+++ b/test/index.js
@@ -57,7 +57,8 @@ describe('Feed generator', () => {
       limit: 3
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
 
     result.path.should.eql('atom.xml');
     result.data.should.eql(atomTmpl.render({
@@ -75,7 +76,8 @@ describe('Feed generator', () => {
       limit: 3
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
 
     result.path.should.eql('rss2.xml');
     result.data.should.eql(rss2Tmpl.render({
@@ -93,8 +95,8 @@ describe('Feed generator', () => {
       limit: 0
     };
     hexo.config = Object.assign(hexo.config, urlConfig);
-
-    const result = generator(locals);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
 
     result.path.should.eql('atom.xml');
     result.data.should.eql(atomTmpl.render({
@@ -111,7 +113,8 @@ describe('Feed generator', () => {
       path: 'rss2.xml',
       content: true
     };
-    let result = generator(locals);
+    let feedCfg = hexo.config.feed;
+    let result = generator(locals, feedCfg.type, feedCfg.path);
     let $ = cheerio.load(result.data, {xmlMode: true});
 
     let description = $('content\\:encoded').html()
@@ -125,7 +128,8 @@ describe('Feed generator', () => {
       path: 'atom.xml',
       content: true
     };
-    result = generator(locals);
+    feedCfg = hexo.config.feed;
+    result = generator(locals, feedCfg.type, feedCfg.path);
     $ = cheerio.load(result.data, {xmlMode: true});
     description = $('content[type="html"]').html()
       .replace(/^<!\[CDATA\[/, '')
@@ -145,7 +149,8 @@ describe('Feed generator', () => {
       hexo.config.url = url;
       hexo.config.root = root;
 
-      const result = generator(locals);
+      const feedCfg = hexo.config.feed;
+      const result = generator(locals, feedCfg.type, feedCfg.path);
       const $ = cheerio.load(result.data);
 
       $('feed>id').text().should.eql(valid);
@@ -174,7 +179,8 @@ describe('Feed generator', () => {
       hexo.config.url = url;
       hexo.config.root = root;
 
-      const result = generator(locals);
+      const feedCfg = hexo.config.feed;
+      const result = generator(locals, feedCfg.type, feedCfg.path);
       const $ = cheerio.load(result.data);
 
       if (url[url.length - 1] !== '/') url += '/';
@@ -200,7 +206,8 @@ describe('Feed generator', () => {
       hexo.config.url = domain;
       hexo.config.root = root;
 
-      const result = generator(locals);
+      const feedCfg = hexo.config.feed;
+      const result = generator(locals, feedCfg.type, feedCfg.path);
       const $ = cheerio.load(result.data);
 
       $('feed>link').attr('href').should.eql(valid);
@@ -220,7 +227,8 @@ describe('Feed generator', () => {
       hexo.config.url = url;
       hexo.config.root = root;
 
-      const result = generator(locals);
+      const feedCfg = hexo.config.feed;
+      const result = generator(locals, feedCfg.type, feedCfg.path);
       const $ = cheerio.load(result.data);
 
       $(selector).length.should.eq(1);

--- a/test/index.js
+++ b/test/index.js
@@ -293,6 +293,20 @@ describe('Feed generator', () => {
 
     $('rss>channel>image').length.should.eql(0);
   });
+
+  it('path must follow order of type', () => {
+    hexo.config.feed = {
+      type: ['rss2', 'atom'],
+      path: ['rss-awesome.xml', 'atom-awesome.xml'],
+    };
+    hexo.config = Object.assign(hexo.config, urlConfig);
+
+    const rss = generator(locals, hexo.config.feed.type[0]);
+    rss.path.should.eql(hexo.config.feed.path[0]);
+
+    const atom = generator(locals, hexo.config.feed.type[1]);
+    atom.path.should.eql(hexo.config.feed.path[1]);
+  });
 });
 
 describe('Autodiscovery', () => {


### PR DESCRIPTION
Fix #59 

How to test:
``` diff
package.json
-  "hexo-generator-feed": "^2.0.0"
+  "hexo-generator-feed": "curbengh/hexo-generator-feed#atom-rss2"
```

``` sh
$ rm -rf node_modules/ && npm i
```

``` yml
_config.yml
feed:
  type:
    - 'atom'
    - 'rss2'
```

``` sh
$ hexo clean && hexo g
```

cc @mythsman