### PR TITLE
Updated Atom.xml to use correct namespace

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ config.title }}</title>
   {% if icon %}<icon>{{ icon }}</icon>{% endif %}
   {% if config.subtitle %}<subtitle>{{ config.subtitle }}</subtitle>{% endif %}


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc4287#section-1.2, the correct xml namespace is "http://www.w3.org/2005/Atom". When https is used, some feed validators will fail validation, even though the "https" version of that URL is also valid.  

fixes #104