### PR TITLE
Fix wrong config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ You can configure this plugin in `_config.yml`.
 
 ``` yaml
 feed:
-  type: atom
-  path: atom.xml
+  type: 
+    - atom
+  path: 
+    - atom.xml
   limit: 20
   hub:
   content:
@@ -42,7 +44,8 @@ feed:
   ``` yaml
   feed:
     # Generate atom feed
-    type: atom
+    type: 
+      - atom
 
     # Generate both atom and rss2 feeds
     type:


### PR DESCRIPTION
The original config example will cause Exception of type.foreach is not a function.