### PR TITLE
handle sites with no posts

### DIFF
--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -9,7 +9,7 @@ function autodiscoveryInject(data) {
   const path = feed.path;
   let autodiscoveryTag = '';
 
-  if (data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i)) return;
+  if (data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i) || feed.autodiscovery === false) return;
 
   type.forEach((feedType, i) => {
     autodiscoveryTag += `<link rel="alternate" href="${url_for.call(this, path[i])}" `

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -29,8 +29,8 @@ module.exports = function(locals, type, path) {
     return post.draft !== true;
   });
 
-  if (posts.length < 1) {
-    return null;
+  if (posts.length <= 0) {
+    return;
   }
 
   if (feedConfig.limit) posts = posts.limit(feedConfig.limit);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -30,6 +30,7 @@ module.exports = function(locals, type, path) {
   });
 
   if (posts.length <= 0) {
+    feedConfig.autodiscovery = false;
     return;
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -29,6 +29,10 @@ module.exports = function(locals, type, path) {
     return post.draft !== true;
   });
 
+  if (posts.length < 1) {
+    return null;
+  }
+
   if (feedConfig.limit) posts = posts.limit(feedConfig.limit);
 
   let url = config.url;

--- a/test/index.js
+++ b/test/index.js
@@ -322,6 +322,30 @@ describe('Feed generator', () => {
   });
 });
 
+it('No posts', () => {
+  const hexo = new Hexo(__dirname, {
+    silent: true
+  });
+  const Post = hexo.model('Post');
+  const generator = require('../lib/generator').bind(hexo);
+
+  require('../node_modules/hexo/lib/plugins/helper')(hexo);
+
+  hexo.config.feed = {
+    type: 'atom',
+    path: 'atom.xml'
+  };
+  hexo.config = Object.assign(hexo.config, urlConfig);
+  const feedCfg = hexo.config.feed;
+
+  return Post.insert([]).then(data => {
+    const locals = hexo.locals.toObject();
+    const result = typeof generator(locals, feedCfg.type, feedCfg.path);
+
+    result.should.eql('undefined');
+  });
+});
+
 describe('Autodiscovery', () => {
   const hexo = new Hexo();
   const autoDiscovery = require('../lib/autodiscovery').bind(hexo);

--- a/test/index.js
+++ b/test/index.js
@@ -355,10 +355,10 @@ describe('Autodiscovery', () => {
   };
   hexo.config.feed = {
     type: ['atom'],
-    path: ['atom.xml']
+    path: ['atom.xml'],
+    autodiscovery: true
   };
   hexo.config = Object.assign(hexo.config, urlConfig);
-
 
   it('default', () => {
     const content = '<head><link></head>';
@@ -368,6 +368,17 @@ describe('Autodiscovery', () => {
     $('link[type="application/atom+xml"]').length.should.eql(1);
     $('link[type="application/atom+xml"]').attr('href').should.eql(urlConfig.root + hexo.config.feed.path);
     $('link[type="application/atom+xml"]').attr('title').should.eql(hexo.config.title);
+  });
+
+  it('disable', () => {
+    hexo.config.feed.autodiscovery = false;
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+
+    hexo.config.feed.autodiscovery = true;
   });
 
   it('prepend root', () => {


### PR DESCRIPTION
see https://github.com/tomap/hexo-theme-minidyne-demo/pull/5/commits/2ddea217338f62bdfba9f1d8f83d106d6f9e6d0c

The fix is a bit dumb, but I don't feel we need to generate an empty atom or rss file in that case.

Related to issue #43 (last comments)