### PR TITLE
feat: custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ feed:
   * It is possible to specify just one custom template, even when this plugin is configured to output both feed types,
   ``` yaml
   # (Optional) Exclude custom template from being copied into public/ folder
+  # Alternatively, you could also prepend an underscore to its filename, e.g. _custom.xml
   # https://hexo.io/docs/configuration#Include-Exclude-Files-or-Folders
   exclude:
     - 'custom.xml'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ feed:
   order_by: -date
   icon: icon.png
   autodiscovery: true
+  template:
 ```
 
 - **type** - Feed type. `atom` or `rss2`. Specify `['atom', 'rss2']` to output both types. (Default: `atom`)
@@ -63,3 +64,19 @@ feed:
 - **icon** - (optional) Custom feed icon. Defaults to a gravatar of email specified in the main config.
 - **autodiscovery** - Add feed [autodiscovery](http://www.rssboard.org/rss-autodiscovery). (Default: `true`)
   * Many themes already offer this feature, so you may also need to adjust the theme's config if you wish to disable it.
+- **template** - Custom template path(s). This file will be used to generate feed xml file, see the default templates: [atom.xml](atom.xml) and [rss2.xml](rss2.xml).
+  * It is possible to specify just one custom template, even when this plugin is configured to output both feed types,
+  ``` yaml
+  # (Optional) Exclude custom template from being copied into public/ folder
+  # https://hexo.io/docs/configuration#Include-Exclude-Files-or-Folders
+  exclude:
+    - 'custom.xml'
+  feed:
+    type:
+      - atom
+      - rss2
+    template:
+      - ./source/custom.xml
+    # atom will be generated using custom.xml
+    # rss2 will be generated using the default template instead
+  ```

--- a/index.js
+++ b/index.js
@@ -70,12 +70,18 @@ if (typeof path === 'string') {
 }
 
 if (typeof template === 'string') {
-  if (template.length > 0) template = [template];
+  if (template.length >= 1) template = [template];
 }
 
 if (Array.isArray(template)) {
-  if (template.length > 2) template = template.slice(0, 2);
-  if (template.length < type.length) template.push(join(__dirname, `${type[1]}.xml`));
+  if (template.length >= 1) {
+    if (template.length > 2) template = template.slice(0, 2);
+    if (template.length < type.length) template.push(join(__dirname, `${type[1]}.xml`));
+  } else {
+    template = null;
+  }
+} else {
+  template = null;
 }
 
 config.type = type;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const config = hexo.config.feed = Object.assign({
 
 let type = config.type;
 let path = config.path;
+let template = config.template;
 const feedFn = require('./lib/generator');
 
 if (!type || (typeof type !== 'string' && !Array.isArray(type))) {
@@ -67,8 +68,11 @@ if (typeof path === 'string') {
   if (!extname(path)) path += '.xml';
 }
 
+if (typeof template === 'string') template = [template];
+
 config.type = type;
 config.path = path;
+config.template = template;
 
 if (typeof type === 'string') {
   hexo.extend.generator.register(type, locals => {

--- a/index.js
+++ b/index.js
@@ -69,14 +69,13 @@ if (typeof path === 'string') {
   if (!extname(path)) path += '.xml';
 }
 
-if (typeof template === 'string' && template.length > 0) template = [template];
-
-if (Array.isArray(type) && template.length > 2) {
-  template = template.slice(0, 2);
+if (typeof template === 'string') {
+  if (template.length > 0) template = [template];
 }
 
-if (Array.isArray(template) && template.length < type.length) {
-  template.push(join(__dirname, `${type[1]}.xml`));
+if (Array.isArray(template)) {
+  if (template.length > 2) template = template.slice(0, 2);
+  if (template.length < type.length) template.push(join(__dirname, `${type[1]}.xml`));
 }
 
 config.type = type;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* global hexo */
 'use strict';
 
-const { extname } = require('path');
+const { extname, join } = require('path');
 
 const config = hexo.config.feed = Object.assign({
   type: 'atom',
@@ -11,7 +11,8 @@ const config = hexo.config.feed = Object.assign({
   content_limit: 140,
   content_limit_delim: '',
   order_by: '-date',
-  autodiscovery: true
+  autodiscovery: true,
+  template: ''
 }, hexo.config.feed);
 
 let type = config.type;
@@ -68,7 +69,15 @@ if (typeof path === 'string') {
   if (!extname(path)) path += '.xml';
 }
 
-if (typeof template === 'string') template = [template];
+if (typeof template === 'string' && template.length > 0) template = [template];
+
+if (Array.isArray(type) && template.length > 2) {
+  template = template.slice(0, 2);
+}
+
+if (Array.isArray(template) && template.length < type.length) {
+  template.push(join(__dirname, `${type[1]}.xml`));
+}
 
 config.type = type;
 config.path = path;

--- a/index.js
+++ b/index.js
@@ -69,19 +69,17 @@ if (typeof path === 'string') {
   if (!extname(path)) path += '.xml';
 }
 
-if (typeof template === 'string') {
-  if (template.length >= 1) template = [template];
+if (typeof template !== 'string' && !Array.isArray(template)) {
+  template = null;
 }
 
 if (Array.isArray(template)) {
   if (template.length >= 1) {
-    if (template.length > 2) template = template.slice(0, 2);
-    if (template.length < type.length) template.push(join(__dirname, `${type[1]}.xml`));
+    if (template.length > type.length) template = template.slice(0, type.length);
+    else if (template.length < type.length) template.push(join(__dirname, `${type[1]}.xml`));
   } else {
     template = null;
   }
-} else {
-  template = null;
 }
 
 config.type = type;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -18,8 +18,11 @@ module.exports = function(locals, type, path) {
   const config = this.config;
   const feedConfig = config.feed;
 
-  const tmplSrc = feedConfig.template ? feedConfig.template[feedConfig.type.indexOf(type)]
-    : join(__dirname, `../${type}.xml`);
+  let tmplSrc = join(__dirname, `../${type}.xml`);
+  if (feedConfig.template) {
+    if (typeof feedConfig.template === 'string') tmplSrc = feedConfig.template;
+    else tmplSrc = feedConfig.template[feedConfig.type.indexOf(type)];
+  }
   const template = nunjucks.compile(readFileSync(tmplSrc, 'utf8'), env);
 
   let posts = locals.posts.sort(feedConfig.order_by || '-date');

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -14,15 +14,13 @@ env.addFilter('noControlChars', str => {
   return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
 });
 
-const atomTmplSrc = join(__dirname, '../atom.xml');
-const atomTmpl = nunjucks.compile(readFileSync(atomTmplSrc, 'utf8'), env);
-const rss2TmplSrc = join(__dirname, '../rss2.xml');
-const rss2Tmpl = nunjucks.compile(readFileSync(rss2TmplSrc, 'utf8'), env);
-
 module.exports = function(locals, type, path) {
   const config = this.config;
   const feedConfig = config.feed;
-  const template = type === 'atom' ? atomTmpl : rss2Tmpl;
+
+  const tmplSrc = feedConfig.template ? feedConfig.template[feedConfig.type.indexOf(type)]
+    : join(__dirname, `../${type}.xml`);
+  const template = nunjucks.compile(readFileSync(tmplSrc, 'utf8'), env);
 
   let posts = locals.posts.sort(feedConfig.order_by || '-date');
   posts = posts.filter(post => {

--- a/test/custom.xml
+++ b/test/custom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aaa>
+  {% for post in posts.toArray() %}
+  <entry>
+    <published>{{ post.date.toISOString() }}</published>
+  </entry>
+  {% endfor %}
+</aaa>

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,8 @@ const atomTmplSrc = join(__dirname, '../atom.xml');
 const atomTmpl = nunjucks.compile(readFileSync(atomTmplSrc, 'utf8'), env);
 const rss2TmplSrc = join(__dirname, '../rss2.xml');
 const rss2Tmpl = nunjucks.compile(readFileSync(rss2TmplSrc, 'utf8'), env);
+const customTmplSrc = join(__dirname, 'custom.xml');
+const customTmlp = nunjucks.compile(readFileSync(customTmplSrc, 'utf8'), env);
 
 const urlConfig = {
   url: 'http://localhost/',
@@ -319,6 +321,24 @@ describe('Feed generator', () => {
 
     const atom = generator(locals, feedCfg.type[1], feedCfg.path[1]);
     atom.path.should.eql(hexo.config.feed.path[1]);
+  });
+
+  it('custom template', () => {
+    hexo.config.feed = {
+      type: ['atom'],
+      path: 'atom.xml',
+      template: ['test/custom.xml']
+    };
+    hexo.config = Object.assign(hexo.config, urlConfig);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type[0], feedCfg.path);
+
+    result.data.should.eql(customTmlp.render({
+      config: hexo.config,
+      url: urlConfig.url,
+      posts,
+      feed_url: hexo.config.root + feedCfg.path
+    }));
   });
 });
 


### PR DESCRIPTION
As suggested in https://github.com/hexojs/hexo-generator-feed/issues/101#issuecomment-544144090, cc @freak3dot

How to test:

``` diff
package.json
-  "hexo-generator-feed": "^2.0.0"
+  "hexo-generator-feed": "curbengh/hexo-generator-feed#custom-template"
```

``` sh
$ rm -rf node_modules/ && npm i
```

``` yml
_config.yml
# Optional, prevent custom.xml from being copied into public/ folder
exclude:
  - 'custom.xml'
feed:
  type: 'atom'
  template: './source/custom.xml'
```

``` sh
$ hexo clean && hexo g
```

---

Following configs are supported:

``` yml
feed:
  type:
    - 'atom'
    - 'rss2'
  template:
    - './source/_atom.xml'
    - './source/_rss2.xml'
```

``` yml
feed:
  type:
    - 'atom'
    - 'rss2'
  template:
    - './source/_atom.xml'
  # rss2 uses the default template instead
```