### PR TITLE
fix(autodiscovery): check boolean type instead of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ for (const feedType of type) {
   });
 }
 
-if (typeof config.autodiscovery === 'undefined') config.autodiscovery = true;
+if (typeof config.autodiscovery !== 'boolean') config.autodiscovery = true;
 
 if (config.autodiscovery === true) {
   hexo.extend.filter.register('after_render:html', require('./lib/autodiscovery'));


### PR DESCRIPTION
currently L62 only handles `undefined`, not `null` (which is an `object` type). This PR allows it to handle `object`, `number` and `string` types.

`type:` and `path:` also default to an array since a string will always be converted to array.