### PR TITLE
fix: handle zero length 'config.path'

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ if (!path || !Array.isArray(path)) {
 }
 
 if (Array.isArray(path)) {
-  if (path.length > 2) path = path.slice(0, 2);
   if (path.length !== type.length) {
-    if (path.length === 0) path = type.map(str => str.concat('.xml'));
-    else path.push(type[1]);
+    if (path.length > type.length) path = path.slice(0, type.length);
+    else if (path.length === 0) path = type.map(str => str.concat('.xml'));
+    else path.push(type[1].concat('.xml'));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -37,12 +37,18 @@ type = type.map((str, i) => {
   return str;
 });
 
-if (!path || typeof path === 'string' || !Array.isArray(path)) {
+if (typeof path === 'string') path = [path];
+
+if (!path || !Array.isArray(path)) {
   path = type.map(str => str.concat('.xml'));
 }
 
-if (Array.isArray(path) && path.length > 2) {
-  path = path.slice(0, 2);
+if (Array.isArray(path)) {
+  if (path.length > 2) path = path.slice(0, 2);
+  if (path.length !== type.length) {
+    if (path.length === 0) path = type.map(str => str.concat('.xml'));
+    else path.push(type[1]);
+  }
 }
 
 path = path.map(str => {


### PR DESCRIPTION
Handle following edge cases:

``` yml
type:
  - atom
  - rss2
path: 'feed/atom.xml'
# Previously 'feed/atom.xml' was replaced by ['atom.xml', 'rss2']
# Now it should be ['feed/atom.xml', 'rss2.xml']
```

---

The following config previously would error out when executing

https://github.com/hexojs/hexo-generator-feed/blob/dd558c65d1a6dd0a4cc9e6434e13dd552821d320/index.js#L58

``` yml
type:
  - atom
  - rss2
path: 
  - 'feed/atom.xml'
# Previously ['feed/atom.xml'] stays the same
# Now it should be ['feed/atom.xml', 'rss2.xml']
```

---

``` yml
type:
  - atom
  - rss2
path: []
# Previously, path stays empty
# Now it should be ['atom.xml', 'rss2.xml']
```

---

Noticed while testing https://github.com/hexojs/hexo-generator-feed/pull/110