### PR TITLE
fix: compatibility with existing theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,14 +24,21 @@ if (!type || (typeof type !== 'string' && !Array.isArray(type))) {
 
 if (Array.isArray(type)) {
   if (type.length > 2) type = type.slice(0, 2);
-  type = type.map((str, i) => {
-    str = str.toLowerCase();
-    if (str !== 'atom' && str !== 'rss2') {
-      if (i === 0) str = 'atom';
-      else str = 'rss2';
-    }
-    return str;
-  });
+  switch (type.length) {
+    case 0:
+      type = 'atom';
+      break;
+    case 1:
+      if (type[0] !== 'atom' && type[0] !== 'rss2') {
+        type = 'atom';
+      }
+      break;
+    case 2:
+      if (type !== ['atom', 'rss2'] && type !== ['rss2', 'atom']) {
+        type = ['atom', 'rss2'];
+      }
+      break;
+  }
 }
 
 if (typeof type === 'string') {

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -5,16 +5,20 @@ const { url_for } = require('hexo-util');
 function autodiscoveryInject(data) {
   const { config } = this;
   const { feed } = config;
-  const type = feed.type;
-  const path = feed.path;
+  const { path, type } = feed;
   let autodiscoveryTag = '';
 
   if (data.match(/type=['|"]?application\/(atom|rss)\+xml['|"]?/i) || feed.autodiscovery === false) return;
 
-  type.forEach((feedType, i) => {
-    autodiscoveryTag += `<link rel="alternate" href="${url_for.call(this, path[i])}" `
-      + `title="${config.title}" type="application/${feedType.replace(/2$/, '')}+xml">\n`;
-  });
+  if (typeof type === 'string') {
+    autodiscoveryTag += `<link rel="alternate" href="${url_for.call(this, path)}" `
+      + `title="${config.title}" type="application/${type.replace(/2$/, '')}+xml">\n`;
+  } else {
+    type.forEach((feedType, i) => {
+      autodiscoveryTag += `<link rel="alternate" href="${url_for.call(this, path[i])}" `
+        + `title="${config.title}" type="application/${feedType.replace(/2$/, '')}+xml">\n`;
+    });
+  }
 
   return data.replace(/<head>(?!<\/head>).+?<\/head>/s, (str) => str.replace('</head>', `${autodiscoveryTag}</head>`));
 }

--- a/test/index.js
+++ b/test/index.js
@@ -370,6 +370,22 @@ describe('Autodiscovery', () => {
     $('link[type="application/atom+xml"]').attr('title').should.eql(hexo.config.title);
   });
 
+  it('default - string', () => {
+    hexo.config.feed.type = 'atom';
+    hexo.config.feed.path = 'atom.xml';
+
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content).trim();
+
+    const $ = cheerio.load(result);
+    $('link[type="application/atom+xml"]').length.should.eql(1);
+    $('link[type="application/atom+xml"]').attr('href').should.eql(urlConfig.root + hexo.config.feed.path);
+    $('link[type="application/atom+xml"]').attr('title').should.eql(hexo.config.title);
+
+    hexo.config.feed.type = ['atom'];
+    hexo.config.feed.path = ['atom.xml'];
+  });
+
   it('disable', () => {
     hexo.config.feed.autodiscovery = false;
     const content = '<head><link></head>';

--- a/test/index.js
+++ b/test/index.js
@@ -366,7 +366,7 @@ describe('Autodiscovery', () => {
 
     const $ = cheerio.load(result);
     $('link[type="application/atom+xml"]').length.should.eql(1);
-    $('link[type="application/atom+xml"]').attr('href').should.eql(urlConfig.root + hexo.config.feed.path);
+    $('link[type="application/atom+xml"]').attr('href').should.eql(urlConfig.root + hexo.config.feed.path[0]);
     $('link[type="application/atom+xml"]').attr('title').should.eql(hexo.config.title);
   });
 
@@ -403,7 +403,7 @@ describe('Autodiscovery', () => {
     const result = autoDiscovery(content);
 
     const $ = cheerio.load(result);
-    $('link[type="application/atom+xml"]').attr('href').should.eql(hexo.config.root + hexo.config.feed.path);
+    $('link[type="application/atom+xml"]').attr('href').should.eql(hexo.config.root + hexo.config.feed.path[0]);
 
     hexo.config.root = '/';
   });


### PR DESCRIPTION
Fixes #112 

Existing theme expects `feed.path` to be a string, but previous PR https://github.com/hexojs/hexo-generator-feed/pull/96 converts it to array. This PR prevents the conversion.

cc @mikolaje @yrpang @AlynxZhou @stevenjoezhang