### PR TITLE
style: no-multi-assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 const { extname, join } = require('path');
 
-const config = hexo.config.feed = Object.assign({
+hexo.config.feed = Object.assign({
   type: 'atom',
   limit: 20,
   hub: '',
@@ -14,6 +14,8 @@ const config = hexo.config.feed = Object.assign({
   autodiscovery: true,
   template: ''
 }, hexo.config.feed);
+
+const config = hexo.config.feed;
 
 let type = config.type;
 let path = config.path;


### PR DESCRIPTION
eslint-config-hexo is going to enforce [no-multi-assign](https://github.com/hexojs/eslint-config-hexo/pull/22/files#diff-139d26542d80f293e0b4ff01913d24ccR88).