### PR TITLE
test: use camaro to parse xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
+    "camaro": "^4.1.2",
     "chai": "^4.2.0",
     "cheerio": "^0.22.0",
     "eslint": "^6.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -109,27 +109,30 @@ describe('Feed generator', () => {
     }));
   });
 
-  it('Preserves HTML in the content field', async () => {
-    hexo.config.feed = {
-      type: 'rss2',
-      path: 'rss2.xml',
-      content: true
-    };
-    let feedCfg = hexo.config.feed;
-    let result = generator(locals, feedCfg.type, feedCfg.path);
-
-    const rss = await p(result.data);
-    rss.items[1].description.includes('<h6>TestHTML</h6>').should.eql(true);
-
+  it('Preserves HTML in the content field - atom', async () => {
     hexo.config.feed = {
       type: 'atom',
       path: 'atom.xml',
       content: true
     };
-    feedCfg = hexo.config.feed;
-    result = generator(locals, feedCfg.type, feedCfg.path);
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
     const atom = await p(result.data);
+
     atom.items[1].description.includes('<h6>TestHTML</h6>').should.eql(true);
+  });
+
+  it('Preserves HTML in the content field - rss2', async () => {
+    hexo.config.feed = {
+      type: 'rss2',
+      path: 'rss2.xml',
+      content: true
+    };
+    const feedCfg = hexo.config.feed;
+    const result = generator(locals, feedCfg.type, feedCfg.path);
+    const rss = await p(result.data);
+
+    rss.items[1].description.includes('<h6>TestHTML</h6>').should.eql(true);
   });
 
   it('Relative URL handling', async () => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/* !
+ * Ported from feed-furious 1.0.0 to support async-ed camaro v4+
+ * Licensed MIT (c) 2017 Tuan Anh Tran <https://tuananh.org/>
+ * https://github.com/tuananh/feed-furious
+ */
+
+
+const { transform } = require('camaro');
+
+const template = {
+  rss: {
+    title: 'rss/channel/title',
+    link: 'rss/channel/link|rss/channel/atom:link',
+    icon: {
+      url: 'rss/channel/image/url',
+      title: 'rss/channel/image/title',
+      link: 'rss/channel/image/link'
+    },
+    description: 'rss/channel/description',
+    language: 'rss/channel/language',
+    updated: 'rss/channel/lastBuildDate',
+    published: 'rss/channel/pubDate',
+    items: ['//item', {
+      title: 'title',
+      link: 'link',
+      description: 'description',
+      content: 'content:encoded',
+      image: 'enclosure[@type="image"]/@url',
+      date: 'pubDate',
+      id: 'guid',
+      categories: ['category', '.']
+    }]
+  },
+  atom: {
+    title: 'feed/title',
+    icon: 'feed/icon',
+    updated: 'feed/updated',
+    link: 'feed/link/@href',
+    id: 'feed/id',
+    items: ['//entry', {
+      id: 'id',
+      title: 'title',
+      date: 'published',
+      description: 'summary',
+      content: 'content[@type="html"]',
+      image: 'content[@type="image"]/@src',
+      link: 'link',
+      categories: ['category', '@term']
+    }]
+  }
+};
+
+const detectFeedType = async xml => {
+  const sample = await transform(xml, {
+    rss: 'rss/channel/title',
+    atom: 'feed/title'
+  });
+
+  if (sample.rss) return 'rss';
+  if (sample.atom) return 'atom';
+  throw new Error('unknown feed type');
+};
+
+const parseFeed = async xml => {
+  const type = await detectFeedType(xml);
+  const output = await transform(xml, template[type]);
+  return output;
+};
+
+module.exports = parseFeed;


### PR DESCRIPTION
I find cheerio's syntax a bit clunky to parse the xml. In contrast, camaro parses it into json, which makes it easier to grab a specific element. The package size is [minimal](https://bundlephobia.com/result?p=camaro@4.1.2) (especially compared to [cheerio's](https://bundlephobia.com/result?p=cheerio@1.0.0-rc.3)).

cheerio is still used to parse html, to test autodiscovery.

I started to use camaro in https://github.com/hexojs/hexo-migrator-rss/pull/34.