### PR TITLE
fix(template): remove extra spacing

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -25,35 +25,33 @@
     {% if config.feed.content and post.content %}
     <content type="html"><![CDATA[{{ post.content | noControlChars | safe }}]]></content>
     {% endif %}
-    <summary type="html">
     {% if post.description %}
-      {{ post.description }}
+    <summary type="html">{{ post.description }}</summary>
     {% elif post.intro %}
-      {{ post.intro }}
+    <summary type="html">{{ post.intro }}</summary>
     {% elif post.excerpt %}
-      {{ post.excerpt }}
+    <summary type="html">{{ post.excerpt }}</summary>
     {% elif post.content %}
       {% set short_content = post.content.substring(0, config.feed.content_limit) %}
       {% if config.feed.content_limit_delim %}
         {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
         {% if delim_pos > -1 %}
-          {{ short_content.substring(0, delim_pos) }}
+    <summary type="html">{{ short_content.substring(0, delim_pos) }}</summary>
         {% else %}
-          {{ short_content }}
+    <summary type="html">{{ short_content }}</summary>
         {% endif %}
       {% else %}
-        {{ short_content }}
+    <summary type="html">{{ short_content }}</summary>
       {% endif %}
     {% endif %}
-    </summary>
     {% if post.image %}
-    <content src="{{ url + post.image | uriencode }}" type="image" />
+    <content src="{{ url + post.image | uriencode }}" type="image"/>
     {% endif %}
     {% for category in post.categories.toArray() %}
-      <category term="{{ category.name }}" scheme="{{ url + category.path | uriencode }}"/>
+    <category term="{{ category.name }}" scheme="{{ url + category.path | uriencode }}"/>
     {% endfor %}
     {% for tag in post.tags.toArray() %}
-      <category term="{{ tag.name }}" scheme="{{ url + tag.path | uriencode }}"/>
+    <category term="{{ tag.name }}" scheme="{{ url + tag.path | uriencode }}"/>
     {% endfor %}
   </entry>
   {% endfor %}

--- a/rss2.xml
+++ b/rss2.xml
@@ -23,29 +23,27 @@
       <link>{{ post.permalink | uriencode }}</link>
       <guid>{{ post.permalink | uriencode }}</guid>
       <pubDate>{{ post.date.toDate().toUTCString() }}</pubDate>
-      <description>
       {% if post.description %}
-        {{ post.description }}
+      <description>{{ post.description }}</description>
       {% elif post.intro %}
-        {{ post.intro }}
+      <description>{{ post.intro }}</description>
       {% elif post.excerpt %}
-        {{ post.excerpt }}
+      <description>{{ post.excerpt }}</description>
       {% elif post.content %}
         {% set short_content = post.content.substring(0, config.feed.content_limit) %}
         {% if config.feed.content_limit_delim %}
           {% set delim_pos = short_content.lastIndexOf(config.feed.content_limit_delim) %}
           {% if delim_pos > -1 %}
-            {{ short_content.substring(0, delim_pos) }}
+      <description>{{ short_content.substring(0, delim_pos) }}</description>
           {% else %}
-            {{ short_content }}
+      <description>{{ short_content }}</description>
           {% endif %}
         {% else %}
-          {{ short_content }}
+      <description>{{ short_content }}</description>
         {% endif %}
       {% endif %}
-      </description>
       {% if post.image %}
-      <enclosure url="{{ url + post.image | uriencode }}" type="image" />
+      <enclosure url="{{ url + post.image | uriencode }}" type="image"/>
       {% endif %}
       {% if config.feed.content and post.content %}
       <content:encoded><![CDATA[{{ post.content | noControlChars | safe }}]]></content:encoded>


### PR DESCRIPTION
Current behavior:

``` xml
    <summary type="html">
    
      this is an excerpt
    
    </summary>
```

Expected behavior:

``` xml
    <summary type="html">this is an excerpt</summary>
```