### PR TITLE
fix(parseFeed): parse href attribute not text

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -12,7 +12,7 @@ const { transform } = require('camaro');
 const template = {
   rss: {
     title: 'rss/channel/title',
-    link: 'rss/channel/link|rss/channel/atom:link',
+    link: 'rss/channel/link|rss/channel/atom:link/@href',
     icon: {
       url: 'rss/channel/image/url',
       title: 'rss/channel/image/title',


### PR DESCRIPTION
Valid value in RSS2 is,

``` xml
<atom:link href="http://example.com" rel="self" type="application/rss+xml"/>
```

`rss/channel/atom:link` XPath incorrectly assumes
``` xml
<atom:link>http://example.com</atom:link>
```