### PR TITLE
Render an absolute feed URL

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,12 +44,14 @@ module.exports = function(locals, type, path) {
   if (feedConfig.icon) icon = full_url_for.call(this, feedConfig.icon);
   else if (config.email) icon = gravatar(config.email);
 
+  const feed_url = full_url_for.call(this, path);
+
   const xml = template.render({
     config,
     url,
     icon,
     posts,
-    feed_url: config.root + path
+    feed_url
   });
 
   return {


### PR DESCRIPTION
This PR is an update to #29.

This supposed to be a small PR, but I've encountered some issues regarding the base URL.

The [`full_url_for`](https://github.com/hexojs/hexo-util/blob/master/lib/full_url_for.js#L27) function expects the `config.url` not to end with a forward slash. Otherwise it will create a double slash URL, e.g. `http://example.com//atom.xml` (notice that a double slash replacement happens only _after_ the base URL).

I was wondering how the icon feature (#102) can be using `full_url_for` with the current code and not run into any double slash issues. The answer is: it doesn't handle this case. The [unit tests](https://github.com/hexojs/hexo-generator-feed/pull/102/files#diff-910eb6f57886ca16c136101fb1699231R240) are simply running against a custom base URL without an ending slash.

So I've cleaned up the tests:
- removed the ending slash from the test base URL
- adjusted and added new tests to handle subdirectories correctly (as specified in the [hexo documentation](https://hexo.io/docs/configuration.html#URL))
- hard-coded expected values - it makes a test more reliable and readable

All in all, the RSS code itself was and is correct as far as I can judge it, but the tests were faulty.