### PR TITLE
refactor: utilize full_url_for()

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -45,13 +45,13 @@
       {% endif %}
     {% endif %}
     {% if post.image %}
-    <content src="{{ url + post.image | uriencode }}" type="image"/>
+    <content src="{{ post.image | formatUrl }}" type="image"/>
     {% endif %}
     {% for category in post.categories.toArray() %}
-    <category term="{{ category.name }}" scheme="{{ url + category.path | uriencode }}"/>
+    <category term="{{ category.name }}" scheme="{{ category.permalink }}"/>
     {% endfor %}
     {% for tag in post.tags.toArray() %}
-    <category term="{{ tag.name }}" scheme="{{ url + tag.path | uriencode }}"/>
+    <category term="{{ tag.name }}" scheme="{{ tag.permalink }}"/>
     {% endfor %}
   </entry>
   {% endfor %}

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -19,6 +19,10 @@ module.exports = function(locals, type, path) {
   const { email, feed, url: urlCfg } = config;
   const { icon: iconCfg, limit, order_by, template: templateCfg, type: typeCfg } = feed;
 
+  env.addFilter('formatUrl', str => {
+    return full_url_for.call(this, str);
+  });
+
   let tmplSrc = join(__dirname, `../${type}.xml`);
   if (templateCfg) {
     if (typeof templateCfg === 'string') tmplSrc = templateCfg;

--- a/test/index.js
+++ b/test/index.js
@@ -248,25 +248,26 @@ describe('Feed generator', () => {
       path: 'atom.xml'
     };
 
-    const checkURL = async function(url, root, index) {
+    const checkURL = async function(url, root) {
       hexo.config.url = url;
       hexo.config.root = root;
 
       const feedCfg = hexo.config.feed;
       const result = generator(locals, feedCfg.type, feedCfg.path);
 
-      const feed = await p(result.data);
-      feed.items[index].image.should.not.eql('');
+      const { items } = await p(result.data);
+      const postImg = items.filter(({ image }) => image.length)[0];
+      postImg.image.length.should.not.eql(0);
     };
 
-    await checkURL('http://localhost/', '/', 2);
+    await checkURL('http://localhost/', '/');
 
     hexo.config.feed = {
       type: 'rss2',
       path: 'rss2.xml',
       content: true
     };
-    await checkURL('http://localhost/', '/', 2);
+    await checkURL('http://localhost/', '/');
   });
 
   it('Image should have full link', async () => {


### PR DESCRIPTION
`url + post.image` is problematic because `post.image` may have a slash prefix and cause the result to have double slash.