### PR TITLE
The control character `\r\n` cannot be deleted directly

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -11,7 +11,9 @@ env.addFilter('uriencode', str => {
 });
 
 env.addFilter('noControlChars', str => {
-  return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
+  // eslint-disable-line no-control-regex
+  str = str.replace(/[\x0A\x0D]/g, ' ');
+  return str.replace(/[\x00-\x1F\x7F]/g, '');
 });
 
 module.exports = function(locals, type, path) {

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,9 @@ env.addFilter('uriencode', str => {
 });
 
 env.addFilter('noControlChars', str => {
-  return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
+  // eslint-disable-line no-control-regex
+  str = str.replace(/[\x0A\x0D]/g, ' ');
+  return str.replace(/[\x00-\x1F\x7F]/g, '');
 });
 
 const atomTmplSrc = join(__dirname, '../atom.xml');


### PR DESCRIPTION
Please read <https://github.com/hexojs/hexo-renderer-pandoc/issues/50> for more information.

When I use pandoc to convert markdown to HTML, pandoc will wrap too long links using `\r\n`.

For example, the original text of my Markdown is as follows:

```markdown
[test](https://012345678901234567890123456789012345678)
```

[Pandoc](https://github.com/jgm/pandoc) will give me the following HTML (as a string variable):

```html
'<p><a\r\n' + 
    'href="https://012345678901234567890123456789012345678">test</a></p>\r\n'
```

In the generated RSS subscription text, the content in the `<content>` field is

```html
<content type="html"><![CDATA[<p><ahref="https://012345678901234567890123456789012345678">test</a></p>]]></content>
```

You can see that there is no space between `<a` and `href`, which causes a rendering error.

Because of the following code, `\r\n` are removed as control characters.

```javascript
env.addFilter('noControlChars', str => {
  return str.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
});
```

But in the above situation, `\r\n` cannot be deleted directly, but should be replaced by a space, otherwise it will cause rendering errors.

I replaced `\r\n` with spaces and the problem was solved. 

```javascript
env.addFilter('noControlChars', str => {
  // eslint-disable-line no-control-regex
  str = str.replace(/[\x0A\x0D]/g, ' ');
  return str.replace(/[\x00-\x1F\x7F]/g, '');
});
```

I haven't thought of a case where `\r\n` can't be replaced with spaces for the time being.

This is really an April Fool's Day joke for me, but this issue is not an April Fool's Day joke.
