### PR TITLE
feat: revert lazy-loaded image attributes

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,6 +3,20 @@
 const { generateRssFeed, generateAtomFeed } = require('feedsmith');
 const { gravatar, full_url_for, encodeURL } = require('hexo-util');
 
+function revertLazyload(html) {
+  if (typeof html !== 'string') return html;
+  return html.replace(/<img[^>]+>/ig, img => {
+    const match = img.match(/\s+data-src=(["'])(.*?)\1/i);
+    if (match) {
+      img = img.replace(/\s+src=(["']).*?\1/ig, '');
+      img = img.replace(/\s+data-src=(["'])(.*?)\1/ig, ' src=$1$2$1');
+      img = img.replace(/\s+data-srcset=(["'])(.*?)\1/ig, ' srcset=$1$2$1');
+      img = img.replace(/\s+data-sizes=(["'])(.*?)\1/ig, ' sizes=$1$2$1');
+    }
+    return img;
+  });
+}
+
 function composePosts(posts, feedConfig) {
   const { limit, order_by } = feedConfig;
 
@@ -91,10 +105,10 @@ function composeItem(post, feedConfig, context) {
   return {
     title: post.title,
     link: encodeURL(full_url_for.call(context, post.permalink)),
-    description: composeItemDescription(post, feedConfig),
+    description: revertLazyload(composeItemDescription(post, feedConfig)),
     published: post.date.toDate(),
     updated: post.updated ? post.updated.toDate() : post.date.toDate(),
-    content: composeItemContent(post, feedConfig),
+    content: revertLazyload(composeItemContent(post, feedConfig)),
     enclosures: post.image && [{ url: full_url_for.call(context, post.image) }],
     categories: composeItemCategories(post)
   };

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,13 @@ describe('Feed generator', () => {
         title: 'No Delimiter Test',
         content: 'This content has no delimiter and should be truncated at content_limit.',
         date: 1e8
+      },
+      {
+        source: 'lazyload-test',
+        slug: 'lazyload-test',
+        title: 'LazyLoad Test',
+        content: '<img data-src="https://example.com/image.png" alt="Test" class="lazyload" src="data:image/gif;base64,...">',
+        date: 1e8
       }
     ]);
     locals = hexo.locals.toObject();
@@ -635,6 +642,26 @@ describe('Feed generator', () => {
 
     // Should be truncated at content_limit since delimiter not found
     description.should.eql('This content has no delimiter');
+  });
+
+  it('Reverts lazyloaded images in content', async () => {
+    hexo.config.feed = {
+      type: 'atom',
+      path: 'atom.xml',
+      content: true
+    };
+    hexo.config = Object.assign(hexo.config, urlConfig);
+    const feedCfg = hexo.config.feed;
+    const updatedLocals = hexo.locals.toObject();
+    const result = generator(updatedLocals, feedCfg.type, feedCfg.path);
+
+    const { items } = await p(result.data);
+    const post = items.filter(({ title }) => title === 'LazyLoad Test');
+    post.length.should.eql(1);
+    const { description } = post[0];
+
+    description.should.include('src="https://example.com/image.png"');
+    description.should.not.include('data-src');
   });
 });
 


### PR DESCRIPTION
data-src to src in feed content and descriptions

<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Add test cases for the changes.
- [x] Passed the CI test.

## Description

<!--  Describe your changes and why they are needed  -->

Many Hexo themes use front-end lazy-loading libraries (e.g., [`tuupola/lazyload`](https://github.com/tuupola/lazyload)), which replace the image `src` with a placeholder and move the actual URL to `data-src`. Since RSS readers don't execute JavaScript, these images appear broken in feeds.
This PR fixes this by reverting lazy-loaded attributes in the feed output:
- Restores `data-src` (as well as `data-srcset` and `data-sizes`) back to standard `src`/`srcset`/`sizes`.
- Removes the dummy placeholder `src`.
- Adds a unit test to prevent regressions.
This ensures images render correctly in RSS/Atom readers while keeping lazy-load intact on the blog itself.

## Additional information

I'm completely open to feedback on this! If you think this reverting behavior should be implemented as an optional feature instead of a default (e.g., controlled via a configuration flag like `feed.revert_lazyload: true`), please let me know and I'll be more than happy to update the PR accordingly!